### PR TITLE
fix: handle missing query in redirect URL

### DIFF
--- a/www/lib/class.location.php
+++ b/www/lib/class.location.php
@@ -110,10 +110,10 @@ class Location
         $url = substr($url, $posIndex);
       }
       $urla = parse_url($url);
-      $urla['query'] = $this->prepareQuery($urla['query']);
+      $urla['query'] = isset($urla['query']) ? $this->prepareQuery($urla['query']) : '';
 
-      $url = $this->server.'?'
-        .(!empty($urla['query'])?$urla['query']:'')
+      $url = $this->server
+        .(!empty($urla['query'])?'?'.$urla['query']:'')
         .(!empty($urla['fragment'])?'#'.$urla['fragment']:'');
       return $url;
     }


### PR DESCRIPTION
## Summary
- avoid undefined index when parsing URLs in Location::getLocationUrl
- prevent trailing question mark when no query is present

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68970d6c2888832e82f5028819e74e6f