### PR TITLE
Fix seconds calculation for long intervals

### DIFF
--- a/www/pages/prozessstarter.php
+++ b/www/pages/prozessstarter.php
@@ -357,7 +357,10 @@ class Prozessstarter extends GenProzessstarter {
     if(empty($data)) {
       return [];
     }
-    $seconds = 60 * $interval->i;
+    $seconds = $interval->s
+             + 60 * $interval->i
+             + 3600 * $interval->h
+             + 86400 * $interval->d;
     foreach($data as $key => $arr) {
       $cronjobIntervals = [];
       foreach($arr as $rowIndex => $row) {


### PR DESCRIPTION
## Summary
- Ensure `roundDataDates` accounts for seconds, minutes, hours and days when calculating interval length

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php -r '$i=new DateInterval("PT1H"); $seconds=$i->s+60*$i->i+3600*$i->h+86400*$i->d; echo $seconds."\n";'`
- `php -r '$i=new DateInterval("P1D"); $seconds=$i->s+60*$i->i+3600*$i->h+86400*$i->d; echo $seconds."\n";'`


------
https://chatgpt.com/codex/tasks/task_e_6897174c1cac832e8641b1a1db7de13b