### PR TITLE
Add customizable dashboard widget module

### DIFF
--- a/database/struktur.sql
+++ b/database/struktur.sql
@@ -19435,4 +19435,13 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
+-- Table structure for table `dashboard_widget_settings`
+
+DROP TABLE IF EXISTS `dashboard_widget_settings`;
+CREATE TABLE `dashboard_widget_settings` (
+  `user_id` int(11) NOT NULL,
+  `widget_order` text NOT NULL,
+  PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+
 -- Dump completed on 2020-12-07  8:56:21

--- a/www/js/dashboard.js
+++ b/www/js/dashboard.js
@@ -1,0 +1,21 @@
+$(function(){
+  function loadData(){
+    $.getJSON('dashboardwidget.php?action=data', function(data){
+      $('#sales-today').text(data.sales_today);
+      $('#open-orders').text(data.open_orders);
+    });
+  }
+  loadData();
+  setInterval(loadData, 30000);
+
+  $('#dashboard-widgets').sortable({
+    handle: '.card-title',
+    update: function(){
+      var order = [];
+      $('.dashboard-widget').each(function(){
+        order.push($(this).data('widget'));
+      });
+      $.post('dashboardwidget.php?action=saveorder', {order: order.join(',')});
+    }
+  });
+});

--- a/www/lib/class.dashboardwidget.php
+++ b/www/lib/class.dashboardwidget.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * DashboardWidget
+ *
+ * Fetches KPI data for the dashboard.
+ * Provides configuration to store widget order per user.
+ */
+class DashboardWidget
+{
+    /** @var ApplicationCore */
+    protected $app;
+
+    public function __construct($app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Get total sales for today.
+     *
+     * @return float
+     */
+    public function getSalesToday()
+    {
+        $sum = $this->app->DB->Select("SELECT SUM(gesamtsumme) FROM auftrag WHERE DATE(datum)=CURDATE()");
+        if($sum === null) {
+            return 0.0;
+        }
+        return (float)$sum;
+    }
+
+    /**
+     * Get count of open orders.
+     *
+     * @return int
+     */
+    public function getOpenOrders()
+    {
+        $count = $this->app->DB->Select("SELECT COUNT(*) FROM auftrag WHERE status NOT IN ('abgeschlossen','storniert')");
+        return (int)$count;
+    }
+
+    /**
+     * Load widget order configuration for a user.
+     *
+     * @param int $userId
+     *
+     * @return array
+     */
+    public function getWidgetOrder($userId)
+    {
+        $json = $this->app->DB->Select("SELECT widget_order FROM dashboard_widget_settings WHERE user_id='".(int)$userId."' LIMIT 1");
+        if(!$json){
+            return [];
+        }
+        $data = json_decode($json, true);
+        if(!is_array($data)){
+            return [];
+        }
+        return $data;
+    }
+
+    /**
+     * Persist widget order for a user.
+     *
+     * @param int   $userId
+     * @param array $order
+     */
+    public function saveWidgetOrder($userId, array $order)
+    {
+        $json = $this->app->DB->real_escape_string(json_encode($order));
+        $this->app->DB->Insert("INSERT INTO dashboard_widget_settings (user_id, widget_order) VALUES ('".(int)$userId."', '$json') ON DUPLICATE KEY UPDATE widget_order='$json'");
+    }
+
+    /**
+     * Collect KPI data.
+     *
+     * @return array
+     */
+    public function getKpis()
+    {
+        return [
+            'sales_today'  => $this->getSalesToday(),
+            'open_orders'  => $this->getOpenOrders(),
+        ];
+    }
+}
+

--- a/www/pages/dashboardwidget.php
+++ b/www/pages/dashboardwidget.php
@@ -1,0 +1,55 @@
+<?php
+require_once __DIR__.'/../lib/class.dashboardwidget.php';
+
+class Dashboardwidget
+{
+    /** @var ApplicationCore */
+    public $app;
+
+    public function __construct($app)
+    {
+        $this->app = $app;
+        $this->app->ActionHandlerInit($this);
+        $this->app->ActionHandler('list', 'DashboardWidgetList');
+        $this->app->ActionHandler('data', 'DashboardWidgetData');
+        $this->app->ActionHandler('saveorder', 'DashboardWidgetSaveOrder');
+        $this->app->ActionHandlerListen($app);
+        $this->Install();
+    }
+
+    public function DashboardWidgetList()
+    {
+        $widget = new DashboardWidget($this->app);
+        $kpis = $widget->getKpis();
+        $this->app->Tpl->Set('sales_today', $kpis['sales_today']);
+        $this->app->Tpl->Set('open_orders', $kpis['open_orders']);
+        $this->app->Tpl->Parse('PAGE', 'dashboard.tpl');
+    }
+
+    public function DashboardWidgetData()
+    {
+        $widget = new DashboardWidget($this->app);
+        header('Content-Type: application/json');
+        echo json_encode($widget->getKpis());
+        exit;
+    }
+
+    public function DashboardWidgetSaveOrder()
+    {
+        $orderString = $this->app->Secure->GetPOST('order');
+        $order = $orderString ? explode(',', $orderString) : [];
+        $widget = new DashboardWidget($this->app);
+        $userId = method_exists($this->app->User, 'GetID') ? $this->app->User->GetID() : 0;
+        $widget->saveWidgetOrder($userId, $order);
+        header('Content-Type: application/json');
+        echo json_encode(['status' => 'ok']);
+        exit;
+    }
+
+    public function Install()
+    {
+        $this->app->erp->CheckTable('dashboard_widget_settings', 'user_id');
+        $this->app->erp->CheckColumn('user_id', 'int(11)', 'dashboard_widget_settings', 'NOT NULL');
+        $this->app->erp->CheckColumn('widget_order', 'text', 'dashboard_widget_settings', 'NOT NULL');
+    }
+}

--- a/www/templates/dashboard.tpl
+++ b/www/templates/dashboard.tpl
@@ -1,0 +1,23 @@
+{* Dashboard Template *}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+<div id="dashboard-widgets" class="row">
+  <div class="col-12 col-md-6 mb-3 dashboard-widget" data-widget="sales">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">Sales Today</h5>
+        <p class="card-text" id="sales-today">{$sales_today}</p>
+      </div>
+    </div>
+  </div>
+  <div class="col-12 col-md-6 mb-3 dashboard-widget" data-widget="open_orders">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">Open Orders</h5>
+        <p class="card-text" id="open-orders">{$open_orders}</p>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
+<script src="js/dashboard.js"></script>


### PR DESCRIPTION
## Summary
- add DashboardWidget class for sales and open order KPIs and widget ordering
- introduce Bootstrap-based dashboard template and sortable JS
- expose dashboardwidget page endpoints for AJAX updates and settings persistence
- ensure dashboard widget settings table is created via install routine and schema updates

## Testing
- `php -l www/lib/class.dashboardwidget.php`
- `php -l www/pages/dashboardwidget.php`


------
https://chatgpt.com/codex/tasks/task_e_68971f1a9474832e8937d7617b694d8c