### PR TITLE
Add cache layer and migration optimizations

### DIFF
--- a/classes/Components/Cache/ReportCache.php
+++ b/classes/Components/Cache/ReportCache.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Xentral\Components\Cache;
+
+use ApplicationCore;
+use RuntimeException;
+
+/**
+ * Simple cache wrapper that supports APCu and Redis backends.
+ * Used to cache expensive report queries such as sales numbers.
+ */
+class ReportCache
+{
+    /** @var ApplicationCore */
+    private $app;
+
+    /** @var string */
+    private $backend;
+
+    /** @var \Redis|null */
+    private $redis;
+
+    /**
+     * @param ApplicationCore $app
+     * @param array           $options ['backend' => 'redis'|'apcu', 'host' => '', 'port' => 6379]
+     */
+    public function __construct(ApplicationCore $app, array $options = [])
+    {
+        $this->app = $app;
+        $this->backend = $options['backend'] ?? (function_exists('apcu_fetch') ? 'apcu' : 'redis');
+
+        if ($this->backend === 'redis') {
+            if (!extension_loaded('redis')) {
+                throw new RuntimeException('Redis extension not available');
+            }
+            $host = $options['host'] ?? '127.0.0.1';
+            $port = $options['port'] ?? 6379;
+            $this->redis = new \Redis();
+            $this->redis->connect($host, $port);
+        }
+    }
+
+    /**
+     * Retrieve cached value by key.
+     * Runs hook `report_cache_hit` or `report_cache_miss` for monitoring.
+     *
+     * @param string $key
+     *
+     * @return mixed|null
+     */
+    public function get(string $key)
+    {
+        $value = null;
+        if ($this->backend === 'redis') {
+            $value = $this->redis->get($key);
+        } elseif ($this->backend === 'apcu') {
+            $success = false;
+            $value = apcu_fetch($key, $success);
+            if (!$success) {
+                $value = null;
+            }
+        }
+
+        if ($value !== null) {
+            $this->app->erp->RunHook('report_cache_hit', 1, $key);
+        } else {
+            $this->app->erp->RunHook('report_cache_miss', 1, $key);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Store value in cache
+     *
+     * @param string $key
+     * @param mixed  $value
+     * @param int    $ttl   Lifetime in seconds
+     *
+     * @return void
+     */
+    public function set(string $key, $value, int $ttl = 3600): void
+    {
+        if ($this->backend === 'redis') {
+            $this->redis->setex($key, $ttl, serialize($value));
+        } elseif ($this->backend === 'apcu') {
+            apcu_store($key, $value, $ttl);
+        }
+    }
+
+    /**
+     * Convenience wrapper to remember a value for given key.
+     *
+     * @param string   $key
+     * @param int      $ttl
+     * @param callable $callback
+     *
+     * @return mixed
+     */
+    public function remember(string $key, int $ttl, callable $callback)
+    {
+        $cached = $this->get($key);
+        if ($cached !== null) {
+            return is_string($cached) && $this->backend === 'redis' ? unserialize($cached) : $cached;
+        }
+        $value = $callback();
+        $this->set($key, $value, $ttl);
+        return $value;
+    }
+}

--- a/classes/Modules/Migration/XentralIncrementalMigration.php
+++ b/classes/Modules/Migration/XentralIncrementalMigration.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Xentral\Modules\Migration;
+
+use ApplicationCore;
+use DateTimeInterface;
+
+/**
+ * Service to perform incremental migrations from Xentral data sources.
+ * Demonstrates use of prepared statements and index optimisations.
+ */
+class XentralIncrementalMigration
+{
+    /** @var ApplicationCore */
+    private $app;
+
+    public function __construct(ApplicationCore $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Ensure necessary indexes exist for fast incremental queries.
+     * Example adds index on column `letztebearbeitung` of table `auftrag`.
+     */
+    public function ensureIndexes(): void
+    {
+        $sql = 'CREATE INDEX IF NOT EXISTS idx_auftrag_letztebearbeitung ON auftrag (letztebearbeitung)';
+        @$this->app->DB->Query($sql);
+    }
+
+    /**
+     * Fetch orders changed since last sync using prepared statements.
+     *
+     * @param DateTimeInterface $since Timestamp of last migration
+     * @param int               $limit Batch size
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function fetchUpdatedOrders(DateTimeInterface $since, int $limit = 100): array
+    {
+        $this->ensureIndexes();
+        $mysqli = $this->app->DB->connection;
+        $sql = 'SELECT id, letztebearbeitung FROM auftrag
+                WHERE letztebearbeitung > ?
+                ORDER BY letztebearbeitung ASC
+                LIMIT ?';
+        $stmt = $mysqli->prepare($sql);
+        $time = $since->format('Y-m-d H:i:s');
+        $stmt->bind_param('si', $time, $limit);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        return $result->fetch_all(MYSQLI_ASSOC);
+    }
+}

--- a/classes/Modules/Monitoring/CacheMonitor.php
+++ b/classes/Modules/Monitoring/CacheMonitor.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Xentral\Modules\Monitoring;
+
+use ApplicationCore;
+
+/**
+ * Simple monitoring module that counts cache hits and misses.
+ * Metrics can be extended to integrate with external monitoring solutions.
+ */
+class CacheMonitor
+{
+    /** @var ApplicationCore */
+    private $app;
+
+    /** @var int */
+    private $hits = 0;
+
+    /** @var int */
+    private $misses = 0;
+
+    public function __construct(ApplicationCore $app)
+    {
+        $this->app = $app;
+        $this->app->erp->RegisterHook('report_cache_hit', 'cachemonitor', 'onCacheHit');
+        $this->app->erp->RegisterHook('report_cache_miss', 'cachemonitor', 'onCacheMiss');
+    }
+
+    /**
+     * Hook callback for cache hit
+     *
+     * @param string $key
+     */
+    public function onCacheHit($key): void
+    {
+        $this->hits++;
+    }
+
+    /**
+     * Hook callback for cache miss
+     *
+     * @param string $key
+     */
+    public function onCacheMiss($key): void
+    {
+        $this->misses++;
+    }
+
+    /**
+     * @return array{hits:int,misses:int}
+     */
+    public function getStats(): array
+    {
+        return ['hits' => $this->hits, 'misses' => $this->misses];
+    }
+}

--- a/phpwf/class.application_core.php
+++ b/phpwf/class.application_core.php
@@ -63,6 +63,11 @@ class ApplicationCore
     $registry->add('LegacyApplication', $this);
     $this->Container = $registry->get('ServiceContainer');
 
+    // Initialise monitoring module to collect cache statistics
+    if (class_exists('Xentral\\Modules\\Monitoring\\CacheMonitor')) {
+      new \Xentral\Modules\Monitoring\CacheMonitor($this);
+    }
+
     $this->getter = array(
       'User'=>array('class'=>'User','app'=>true),
       'Tpl'=>array('class'=>'TemplateParser','app'=>true),

--- a/www/pages/berichte.php
+++ b/www/pages/berichte.php
@@ -796,5 +796,28 @@ class Berichte extends GenBerichte {
 
       $this->app->Tpl->Add('MESSAGE', $message);
   }
+
+  /**
+   * Example: get cached sales report using prepared statements.
+   *
+   * @param string $startDate
+   * @param string $endDate
+   *
+   * @return array|null
+   */
+  public function GetSalesReportCached($startDate, $endDate)
+  {
+    $cache = new \Xentral\Components\Cache\ReportCache($this->app);
+    $key = 'sales_report_' . $startDate . '_' . $endDate;
+    return $cache->remember($key, 3600, function() use ($startDate, $endDate) {
+      $mysqli = $this->app->DB->connection;
+      $sql = 'SELECT SUM(gesamtbetrag) AS summe FROM rechnung WHERE datum BETWEEN ? AND ?';
+      $stmt = $mysqli->prepare($sql);
+      $stmt->bind_param('ss', $startDate, $endDate);
+      $stmt->execute();
+      $result = $stmt->get_result();
+      return $result->fetch_assoc();
+    });
+  }
 }
 


### PR DESCRIPTION
## Summary
- Add ReportCache wrapper supporting Redis or APCu and exposing hooks for monitoring
- Introduce CacheMonitor module to track cache hit/miss statistics
- Provide XentralIncrementalMigration service with indexed, prepared queries for incremental data migration
- Integrate monitoring at application startup and add cached sales report example

## Testing
- `php -l classes/Components/Cache/ReportCache.php`
- `php -l classes/Modules/Monitoring/CacheMonitor.php`
- `php -l classes/Modules/Migration/XentralIncrementalMigration.php`
- `php -l www/pages/berichte.php`
- `php -l phpwf/class.application_core.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689723316b58832e9bc9f462de0ce947