### PR TITLE
Add time tracking and vacation planning module

### DIFF
--- a/database/timetracker.sql
+++ b/database/timetracker.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS `timetracker_logs` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `start_time` datetime NOT NULL,
+  `end_time` datetime NOT NULL,
+  `project_id` int(11) DEFAULT NULL,
+  `notes` text,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `vacation_requests` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `start_date` date NOT NULL,
+  `end_date` date NOT NULL,
+  `status` enum('pending','approved','rejected') NOT NULL DEFAULT 'pending',
+  `approver_id` int(11) DEFAULT NULL,
+  `reason` text,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/languages/englisch/variablen.php
+++ b/languages/englisch/variablen.php
@@ -3467,3 +3467,7 @@ $variablen['Kosten Gesamt']['default']['default'] = 'Total costs';
 $variablen['Gruppe/Verband']['default']['default'] = 'Group/organization';
 $variablen['Anzahl Auftr&auml;ge']['default']['default'] = 'Number of sales orders';
 $variablen['Kd.-/Verbands-Nr.']['default']['default'] = 'Customer/org. no.';
+$variablen['Zeiterfassung']['menu']['default'] = 'Time tracking';
+$variablen['Zeiterfassung']['default']['default'] = 'time tracking';
+$variablen['Urlaubsplanung']['menu']['default'] = 'Vacation planner';
+$variablen['Urlaubsplanung']['default']['default'] = 'vacation planner';

--- a/www/lib/class.timetracker.php
+++ b/www/lib/class.timetracker.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * TimeTracker handles logging and retrieving working times.
+ * It also offers a simple calendar sync to Google or Outlook via cURL.
+ */
+class TimeTracker
+{
+    /** @var \DB $db */
+    protected $db;
+
+    public function __construct($db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * Log a working time entry.
+     *
+     * @param int       $userId
+     * @param string    $start     Datetime string
+     * @param string    $end       Datetime string
+     * @param int|null  $projectId Optional project reference
+     * @param string    $notes     Optional comment
+     */
+    public function logTime($userId, $start, $end, $projectId = null, $notes = '')
+    {
+        $sql = "INSERT INTO timetracker_logs (user_id, start_time, end_time, project_id, notes) VALUES (?, ?, ?, ?, ?)";
+        $params = [$userId, $start, $end, $projectId, $notes];
+        $this->db->Insert($sql, $params);
+    }
+
+    /**
+     * Return time entries for a user within a date range.
+     *
+     * @param int    $userId
+     * @param string $from   Date string (Y-m-d)
+     * @param string $to     Date string (Y-m-d)
+     *
+     * @return array
+     */
+    public function getLogs($userId, $from, $to)
+    {
+        $sql = "SELECT id, start_time, end_time, project_id, notes FROM timetracker_logs WHERE user_id = ? AND start_time BETWEEN ? AND ?";
+        return $this->db->SelectArr($sql, [$userId, $from . ' 00:00:00', $to . ' 23:59:59']);
+    }
+
+    /**
+     * Synchronise an event to an external calendar provider.
+     *
+     * @param string $provider google|outlook
+     * @param array  $event    [title,start,end]
+     * @param string $token    OAuth access token
+     *
+     * @return string|null     Response body or null on failure
+     */
+    public function syncCalendar($provider, array $event, $token)
+    {
+        if ($provider === 'google') {
+            $url = 'https://www.googleapis.com/calendar/v3/calendars/primary/events';
+        } elseif ($provider === 'outlook') {
+            $url = 'https://graph.microsoft.com/v1.0/me/events';
+        } else {
+            return null;
+        }
+
+        $payload = json_encode([
+            'subject' => $event['title'],
+            'start'   => ['dateTime' => $event['start'], 'timeZone' => 'UTC'],
+            'end'     => ['dateTime' => $event['end'], 'timeZone' => 'UTC'],
+        ]);
+
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Authorization: Bearer ' . $token,
+            'Content-Type: application/json',
+        ]);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+        $result = curl_exec($ch);
+        curl_close($ch);
+
+        return $result;
+    }
+}

--- a/www/lib/class.vacationplanner.php
+++ b/www/lib/class.vacationplanner.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * VacationPlanner manages vacation requests and approvals.
+ * It can synchronise approved vacations with external calendars.
+ */
+class VacationPlanner
+{
+    /** @var \DB $db */
+    protected $db;
+    /** @var TimeTracker */
+    protected $tracker;
+
+    public function __construct($db, TimeTracker $tracker)
+    {
+        $this->db      = $db;
+        $this->tracker = $tracker;
+    }
+
+    /**
+     * Create a vacation request.
+     *
+     * @param int    $userId
+     * @param string $from     Date string (Y-m-d)
+     * @param string $to       Date string (Y-m-d)
+     * @param string $reason   Optional comment
+     */
+    public function requestVacation($userId, $from, $to, $reason = '')
+    {
+        $sql = "INSERT INTO vacation_requests (user_id, start_date, end_date, reason) VALUES (?, ?, ?, ?)";
+        $this->db->Insert($sql, [$userId, $from, $to, $reason]);
+    }
+
+    /**
+     * Approve a vacation request and push it to external calendar.
+     *
+     * @param int    $requestId
+     * @param int    $approverId
+     * @param string $provider
+     * @param string $token
+     */
+    public function approveVacation($requestId, $approverId, $provider = '', $token = '')
+    {
+        $row = $this->db->SelectArr("SELECT * FROM vacation_requests WHERE id = ?", [$requestId]);
+        if (empty($row)) {
+            return;
+        }
+        $data = $row[0];
+        $this->db->Update("UPDATE vacation_requests SET status = 'approved', approver_id = ? WHERE id = ?", [$approverId, $requestId]);
+
+        if ($provider && $token) {
+            $event = [
+                'title' => 'Vacation',
+                'start' => $data['start_date'] . 'T00:00:00',
+                'end'   => $data['end_date'] . 'T23:59:59',
+            ];
+            $this->tracker->syncCalendar($provider, $event, $token);
+        }
+    }
+
+    /**
+     * Get vacation requests for a user.
+     *
+     * @param int $userId
+     *
+     * @return array
+     */
+    public function getRequests($userId)
+    {
+        $sql = "SELECT * FROM vacation_requests WHERE user_id = ? ORDER BY start_date";
+        return $this->db->SelectArr($sql, [$userId]);
+    }
+}

--- a/www/pages/benutzer.php
+++ b/www/pages/benutzer.php
@@ -114,6 +114,7 @@ class Benutzer
     $this->app->erp->MenuEintrag("index.php?module=benutzer&action=history","Historie");
     $this->app->erp->MenuEintrag("index.php?module=benutzer&action=create","Neuen Benutzer anlegen");
     $this->app->erp->MenuEintrag("index.php?module=einstellungen&action=list","Zur&uuml;ck zur &Uuml;bersicht");
+    $this->app->erp->MenuEintrag("index.php?module=timetracker&action=calendar","Zeiterfassung");
 
     $this->app->YUI->TableSearch('USER_TABLE',"userlist");
     $this->app->Tpl->Parse('PAGE', "benutzer_list.tpl");

--- a/www/pages/content/timetracker_calendar.tpl
+++ b/www/pages/content/timetracker_calendar.tpl
@@ -1,0 +1,15 @@
+<div id="tt-calendar"></div>
+{literal}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" />
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.js"></script>
+<script>
+ document.addEventListener('DOMContentLoaded', function() {
+   var calendarEl = document.getElementById('tt-calendar');
+   var calendar = new FullCalendar.Calendar(calendarEl, {
+     initialView: 'dayGridMonth',
+     events: 'index.php?module=timetracker&action=events'
+   });
+   calendar.render();
+ });
+</script>
+{/literal}

--- a/www/pages/timetracker.php
+++ b/www/pages/timetracker.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Page controller for the time tracker and vacation planner.
+ */
+class Timetracker
+{
+    /** @var Application */
+    protected $app;
+
+    public function __construct($app)
+    {
+        $this->app = $app;
+        $this->app->ActionHandlerInit($this);
+        $this->app->ActionHandler('calendar', 'Calendar');
+        $this->app->ActionHandler('events', 'Events');
+        $this->app->ActionHandler('save', 'Save');
+        $this->app->DefaultActionHandler('calendar');
+        $this->app->ActionHandlerListen($app);
+    }
+
+    /**
+     * Render the calendar view.
+     */
+    public function Calendar()
+    {
+        $this->app->erp->MenuEintrag('index.php?module=timetracker&action=calendar', 'Zeiterfassung');
+        $this->app->Tpl->Parse('PAGE', 'timetracker_calendar.tpl');
+    }
+
+    /**
+     * Provide events in JSON for FullCalendar.
+     */
+    public function Events()
+    {
+        $userId = $this->app->User->GetID();
+        $tracker = new TimeTracker($this->app->DB);
+        $entries = $tracker->getLogs($userId, date('Y-m-01'), date('Y-m-t'));
+        $events = [];
+        foreach ($entries as $row) {
+            $events[] = [
+                'id'    => $row['id'],
+                'title' => $row['notes'],
+                'start' => $row['start_time'],
+                'end'   => $row['end_time'],
+            ];
+        }
+        header('Content-Type: application/json');
+        echo json_encode($events);
+        exit;
+    }
+
+    /**
+     * Persist a new time log from form submission.
+     */
+    public function Save()
+    {
+        $userId = $this->app->User->GetID();
+        $start  = $this->app->Secure->GetPOST('start');
+        $end    = $this->app->Secure->GetPOST('end');
+        $note   = $this->app->Secure->GetPOST('note');
+        $tracker = new TimeTracker($this->app->DB);
+        $tracker->logTime($userId, $start, $end, null, $note);
+        header('Location: index.php?module=timetracker&action=calendar');
+        exit;
+    }
+}


### PR DESCRIPTION
## Summary
- add TimeTracker and VacationPlanner library classes with cURL calendar sync
- create SQL schema and Smarty UI with FullCalendar
- link module from user management for multilingual time and vacation tracking

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689723482eac832ea4a327e0eb0615ae