### PR TITLE
Add marketplace sync skeleton classes and cron jobs

### DIFF
--- a/cronjobs/amazonsync.php
+++ b/cronjobs/amazonsync.php
@@ -1,0 +1,32 @@
+<?php
+require_once dirname(__DIR__) . '/conf/main.conf.php';
+require_once dirname(__DIR__) . '/phpwf/plugins/class.mysql.php';
+require_once dirname(__DIR__) . '/www/lib/class.amazonsync.php';
+
+$conf = new Config();
+$db   = new DB($conf->WFdbhost, $conf->WFdbname, $conf->WFdbuser, $conf->WFdbpass, null, $conf->WFdbport);
+
+function loadMarketplaceConfig(DB $db, $marketplace)
+{
+  $db->Update('CREATE TABLE IF NOT EXISTS marketplace_config (marketplace VARCHAR(20), param VARCHAR(64), value TEXT, PRIMARY KEY (marketplace,param))');
+  $rows = $db->SelectArr('SELECT param, value FROM marketplace_config WHERE marketplace=:m', $marketplace);
+  $config = [];
+  if ($rows) {
+    foreach ($rows as $row) {
+      $config[$row['param']] = $row['value'];
+    }
+  }
+  return $config;
+}
+
+$config = loadMarketplaceConfig($db, 'amazon');
+$sync   = new AmazonSync($db, $config);
+
+try {
+  $sync->syncProducts();
+  $sync->syncOrders();
+  $sync->updateStock();
+  $sync->sendInvoices();
+} catch (Exception $e) {
+  error_log('AmazonSync cronjob failed: ' . $e->getMessage());
+}

--- a/cronjobs/miraklsync.php
+++ b/cronjobs/miraklsync.php
@@ -1,0 +1,32 @@
+<?php
+require_once dirname(__DIR__) . '/conf/main.conf.php';
+require_once dirname(__DIR__) . '/phpwf/plugins/class.mysql.php';
+require_once dirname(__DIR__) . '/www/lib/class.miraklsync.php';
+
+$conf = new Config();
+$db   = new DB($conf->WFdbhost, $conf->WFdbname, $conf->WFdbuser, $conf->WFdbpass, null, $conf->WFdbport);
+
+function loadMarketplaceConfig(DB $db, $marketplace)
+{
+  $db->Update('CREATE TABLE IF NOT EXISTS marketplace_config (marketplace VARCHAR(20), param VARCHAR(64), value TEXT, PRIMARY KEY (marketplace,param))');
+  $rows = $db->SelectArr('SELECT param, value FROM marketplace_config WHERE marketplace=:m', $marketplace);
+  $config = [];
+  if ($rows) {
+    foreach ($rows as $row) {
+      $config[$row['param']] = $row['value'];
+    }
+  }
+  return $config;
+}
+
+$config = loadMarketplaceConfig($db, 'mirakl');
+$sync   = new MiraklSync($db, $config);
+
+try {
+  $sync->syncProducts();
+  $sync->syncOrders();
+  $sync->updateStock();
+  $sync->sendInvoices();
+} catch (Exception $e) {
+  error_log('MiraklSync cronjob failed: ' . $e->getMessage());
+}

--- a/cronjobs/woocommercesync.php
+++ b/cronjobs/woocommercesync.php
@@ -1,0 +1,32 @@
+<?php
+require_once dirname(__DIR__) . '/conf/main.conf.php';
+require_once dirname(__DIR__) . '/phpwf/plugins/class.mysql.php';
+require_once dirname(__DIR__) . '/www/lib/class.woocommercesync.php';
+
+$conf = new Config();
+$db   = new DB($conf->WFdbhost, $conf->WFdbname, $conf->WFdbuser, $conf->WFdbpass, null, $conf->WFdbport);
+
+function loadMarketplaceConfig(DB $db, $marketplace)
+{
+  $db->Update('CREATE TABLE IF NOT EXISTS marketplace_config (marketplace VARCHAR(20), param VARCHAR(64), value TEXT, PRIMARY KEY (marketplace,param))');
+  $rows = $db->SelectArr('SELECT param, value FROM marketplace_config WHERE marketplace=:m', $marketplace);
+  $config = [];
+  if ($rows) {
+    foreach ($rows as $row) {
+      $config[$row['param']] = $row['value'];
+    }
+  }
+  return $config;
+}
+
+$config = loadMarketplaceConfig($db, 'woocommerce');
+$sync   = new WooCommerceSync($db, $config);
+
+try {
+  $sync->syncProducts();
+  $sync->syncOrders();
+  $sync->updateStock();
+  $sync->sendInvoices();
+} catch (Exception $e) {
+  error_log('WooCommerceSync cronjob failed: ' . $e->getMessage());
+}

--- a/www/lib/class.amazonsync.php
+++ b/www/lib/class.amazonsync.php
@@ -1,0 +1,190 @@
+<?php
+/*
+ * Placeholder Amazon synchronization class for OpenXE.
+ * Provides bidirectional communication skeleton via Amazon SP-API SDK.
+ */
+
+class AmazonSync
+{
+  /** @var DB */
+  private $db;
+  /** @var array */
+  private $config;
+
+  public function __construct($db, array $config = [])
+  {
+    $this->db     = $db;
+    $this->config = $config;
+    $this->ensureTables();
+  }
+
+  /**
+   * Fetch basic product information from Amazon SP-API and map to ERP database.
+   */
+  public function syncProducts()
+  {
+    try {
+      $skus = $this->db->SelectArr('SELECT nummer FROM artikel LIMIT 20');
+      if (empty($skus)) {
+        return;
+      }
+      foreach ($skus as $row) {
+        $sku = $row['nummer'];
+        $res = $this->request('GET', '/catalog/v0/items', ['MarketplaceId' => $this->config['marketplace_id'] ?? '', 'SellerSKU' => $sku]);
+        if (empty($res['Items'][0])) {
+          continue;
+        }
+        $item = $res['Items'][0];
+        $name = $item['AttributeSets'][0]['Title'] ?? '';
+        if ($name !== '') {
+          $this->db->Update('UPDATE artikel SET name_de=:name WHERE nummer=:sku', $name, $sku);
+        }
+        $this->db->Insert('REPLACE INTO marketplace_products (marketplace, external_id, sku, stock, data) VALUES ("amazon", :asin, :sku, 0, :data)', $item['Identifiers']['MarketplaceASIN']['ASIN'] ?? '', $sku, json_encode($item));
+      }
+    } catch (Exception $e) {
+      $this->logError('syncProducts: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Retrieve new orders from Amazon and store them locally.
+   */
+  public function syncOrders()
+  {
+    try {
+      $res = $this->request('GET', '/orders/v0/orders', [
+        'MarketplaceIds' => $this->config['marketplace_id'] ?? '',
+        'CreatedAfter'   => gmdate('c', strtotime('-1 day')),
+      ]);
+      if (empty($res['Orders'])) {
+        return;
+      }
+      foreach ($res['Orders'] as $order) {
+        $amazonId = $order['AmazonOrderId'];
+        $exists   = $this->db->Select('SELECT external_id FROM marketplace_orders WHERE marketplace="amazon" AND external_id=:id', $amazonId);
+        if (!$exists) {
+          $this->db->Insert('INSERT INTO marketplace_orders (marketplace, external_id, status, data) VALUES ("amazon", :id, :status, :data)', $amazonId, $order['OrderStatus'], json_encode($order));
+        } else {
+          $this->db->Update('UPDATE marketplace_orders SET status=:status, data=:data WHERE marketplace="amazon" AND external_id=:id', $order['OrderStatus'], json_encode($order), $amazonId);
+        }
+      }
+    } catch (Exception $e) {
+      $this->logError('syncOrders: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Submit inventory feed to Amazon based on local stock levels.
+   */
+  public function updateStock()
+  {
+    try {
+      $rows = $this->db->SelectArr('SELECT sku, stock FROM marketplace_products WHERE marketplace="amazon"');
+      if (empty($rows)) {
+        return;
+      }
+      $feed = [];
+      foreach ($rows as $row) {
+        $feed[] = [
+          'SKU'          => $row['sku'],
+          'Quantity'     => (int)$row['stock'],
+          'FulfillmentCenterID' => 'DEFAULT',
+        ];
+      }
+      $payload = ['inventory' => $feed];
+      $this->request('POST', '/feeds/2021-06-30/feeds', [], [
+        'feedType'  => 'POST_INVENTORY_AVAILABILITY_DATA',
+        'marketplaceIds' => [$this->config['marketplace_id'] ?? ''],
+        'inputFeedDocumentId' => base64_encode(json_encode($payload)),
+      ]);
+    } catch (Exception $e) {
+      $this->logError('updateStock: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Send invoice feed to Amazon for completed orders.
+   */
+  public function sendInvoices()
+  {
+    try {
+      $orders = $this->db->SelectArr('SELECT external_id, data FROM marketplace_orders WHERE marketplace="amazon" AND status="Shipped"');
+      if (empty($orders)) {
+        return;
+      }
+      foreach ($orders as $order) {
+        $data = json_decode($order['data'], true);
+        if (empty($data['AmazonOrderId'])) {
+          continue;
+        }
+        $payload = [
+          'orderId' => $data['AmazonOrderId'],
+          'invoice' => ['document' => base64_encode('PDFDATA')],
+        ];
+        $this->request('POST', '/feeds/2021-06-30/feeds', [], [
+          'feedType' => 'POST_INVOICE_DATA',
+          'marketplaceIds' => [$this->config['marketplace_id'] ?? ''],
+          'inputFeedDocumentId' => base64_encode(json_encode($payload)),
+        ]);
+      }
+    } catch (Exception $e) {
+      $this->logError('sendInvoices: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Execute signed HTTP request to Amazon SP-API.
+   *
+   * @param string $method
+   * @param string $path
+   * @param array  $query
+   * @param array  $body
+   *
+   * @return array|null
+   * @throws Exception
+   */
+  private function request($method, $path, array $query = [], array $body = [])
+  {
+    $endpoint = rtrim($this->config['endpoint'] ?? 'https://sellingpartnerapi-eu.amazon.com', '/');
+    $region   = $this->config['region'] ?? 'eu-west-1';
+    $uri      = $endpoint . $path;
+    if (!empty($query)) {
+      $uri .= '?' . http_build_query($query);
+    }
+
+    $headers = [
+      'content-type'       => 'application/json',
+      'x-amz-access-token' => $this->config['lwa_access_token'] ?? '',
+    ];
+    $request = new \GuzzleHttp\Psr7\Request($method, $uri, $headers, empty($body) ? null : json_encode($body));
+    $signer  = new \Aws\Signature\SignatureV4('execute-api', $region);
+    $credentials = new \Aws\Credentials\Credentials($this->config['access_key'] ?? '', $this->config['secret_key'] ?? '');
+    $signed  = $signer->signRequest($request, $credentials);
+    $client  = new \GuzzleHttp\Client();
+    $response = $client->send($signed);
+    $code = $response->getStatusCode();
+    if ($code >= 400) {
+      throw new Exception('HTTP ' . $code . ': ' . (string)$response->getBody());
+    }
+    return json_decode((string)$response->getBody(), true);
+  }
+
+  /**
+   * Ensure local helper tables exist.
+   */
+  private function ensureTables()
+  {
+    $this->db->Update('CREATE TABLE IF NOT EXISTS marketplace_products (marketplace VARCHAR(20), external_id VARCHAR(64), sku VARCHAR(64), stock INT, data LONGTEXT, PRIMARY KEY(marketplace, external_id))');
+    $this->db->Update('CREATE TABLE IF NOT EXISTS marketplace_orders (marketplace VARCHAR(20), external_id VARCHAR(64), status VARCHAR(32), data LONGTEXT, PRIMARY KEY(marketplace, external_id))');
+  }
+
+  /**
+   * Basic error logging helper.
+   *
+   * @param string $message
+   */
+  private function logError($message)
+  {
+    error_log('[AmazonSync] ' . $message);
+  }
+}

--- a/www/lib/class.miraklsync.php
+++ b/www/lib/class.miraklsync.php
@@ -1,0 +1,165 @@
+<?php
+/*
+ * Placeholder Mirakl synchronization class for OpenXE.
+ * Handles product, order and invoice exchange with Mirakl marketplace.
+ */
+
+class MiraklSync
+{
+  /** @var DB */
+  private $db;
+  /** @var array */
+  private $config;
+
+  public function __construct($db, array $config = [])
+  {
+    $this->db     = $db;
+    $this->config = $config;
+    $this->ensureTables();
+  }
+
+  /**
+   * Retrieve products from Mirakl and store them locally.
+   */
+  public function syncProducts()
+  {
+    try {
+      $products = $this->request('GET', '/api/products');
+      if (empty($products['products'])) {
+        return;
+      }
+      foreach ($products['products'] as $product) {
+        $sku  = $product['product_sku'];
+        $name = $product['title'];
+        $id   = $this->db->Select('SELECT id FROM artikel WHERE nummer=:sku', $sku);
+        if ($id) {
+          $this->db->Update('UPDATE artikel SET name_de=:name WHERE id=:id', $name, $id);
+        } else {
+          $this->db->Insert('INSERT INTO artikel (typ, nummer, name_de) VALUES ("default", :sku, :name)', $sku, $name);
+        }
+        $this->db->Insert('REPLACE INTO marketplace_products (marketplace, external_id, sku, stock, data) VALUES ("mirakl", :id, :sku, :stock, :data)', $product['product_id'], $sku, $product['quantity'], json_encode($product));
+      }
+    } catch (Exception $e) {
+      $this->logError('syncProducts: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Retrieve Mirakl orders and persist them.
+   */
+  public function syncOrders()
+  {
+    try {
+      $orders = $this->request('GET', '/api/orders');
+      if (empty($orders['orders'])) {
+        return;
+      }
+      foreach ($orders['orders'] as $order) {
+        $externalId = $order['id'];
+        $exists = $this->db->Select('SELECT external_id FROM marketplace_orders WHERE marketplace="mirakl" AND external_id=:id', $externalId);
+        if (!$exists) {
+          $this->db->Insert('INSERT INTO marketplace_orders (marketplace, external_id, status, data) VALUES ("mirakl", :id, :status, :data)', $externalId, $order['order_state'], json_encode($order));
+        } else {
+          $this->db->Update('UPDATE marketplace_orders SET status=:status, data=:data WHERE marketplace="mirakl" AND external_id=:id', $order['order_state'], json_encode($order), $externalId);
+        }
+      }
+    } catch (Exception $e) {
+      $this->logError('syncOrders: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Push stock levels to Mirakl.
+   */
+  public function updateStock()
+  {
+    try {
+      $rows = $this->db->SelectArr('SELECT external_id, stock FROM marketplace_products WHERE marketplace="mirakl"');
+      if (empty($rows)) {
+        return;
+      }
+      $payload = [];
+      foreach ($rows as $row) {
+        $payload[] = ['product_id' => $row['external_id'], 'quantity' => (int)$row['stock']];
+      }
+      $this->request('POST', '/api/stock', $payload);
+    } catch (Exception $e) {
+      $this->logError('updateStock: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Upload invoices for Mirakl orders.
+   */
+  public function sendInvoices()
+  {
+    try {
+      $orders = $this->db->SelectArr('SELECT external_id, data FROM marketplace_orders WHERE marketplace="mirakl" AND status="SHIPPED"');
+      if (empty($orders)) {
+        return;
+      }
+      foreach ($orders as $order) {
+        $this->request('POST', '/api/orders/' . $order['external_id'] . '/documents', ['type' => 'INVOICE', 'data' => base64_encode('PDFDATA')]);
+      }
+    } catch (Exception $e) {
+      $this->logError('sendInvoices: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Perform HTTP request against Mirakl API.
+   *
+   * @param string       $method
+   * @param string       $endpoint
+   * @param array|string $payload
+   *
+   * @return array|null
+   * @throws Exception
+   */
+  private function request($method, $endpoint, $payload = [])
+  {
+    $base = rtrim($this->config['base_url'] ?? '', '/');
+    if ($base === '') {
+      throw new Exception('Missing base_url config');
+    }
+    $url = $base . $endpoint;
+    $headers = [
+      'X-Mirakl-API-Key: ' . ($this->config['api_key'] ?? ''),
+      'Content-Type: application/json',
+    ];
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+    if ($method !== 'GET') {
+      curl_setopt($ch, CURLOPT_POSTFIELDS, is_string($payload) ? $payload : json_encode($payload));
+    } elseif (!empty($payload) && is_array($payload)) {
+      $url .= '?' . http_build_query($payload);
+      curl_setopt($ch, CURLOPT_URL, $url);
+    }
+    $result = curl_exec($ch);
+    if ($result === false) {
+      throw new Exception(curl_error($ch));
+    }
+    $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($code >= 400) {
+      throw new Exception('HTTP ' . $code . ': ' . $result);
+    }
+    return json_decode($result, true);
+  }
+
+  /**
+   * Ensure helper tables exist for Mirakl sync.
+   */
+  private function ensureTables()
+  {
+    $this->db->Update('CREATE TABLE IF NOT EXISTS marketplace_products (marketplace VARCHAR(20), external_id VARCHAR(64), sku VARCHAR(64), stock INT, data LONGTEXT, PRIMARY KEY(marketplace, external_id))');
+    $this->db->Update('CREATE TABLE IF NOT EXISTS marketplace_orders (marketplace VARCHAR(20), external_id VARCHAR(64), status VARCHAR(32), data LONGTEXT, PRIMARY KEY(marketplace, external_id))');
+  }
+
+  private function logError($message)
+  {
+    error_log('[MiraklSync] ' . $message);
+  }
+}

--- a/www/lib/class.woocommercesync.php
+++ b/www/lib/class.woocommercesync.php
@@ -1,0 +1,167 @@
+<?php
+/*
+ * Placeholder WooCommerce synchronization class for OpenXE.
+ * Uses REST API via cURL for bidirectional data exchange.
+ */
+
+class WooCommerceSync
+{
+  /** @var DB */
+  private $db;
+  /** @var array */
+  private $config;
+
+  public function __construct($db, array $config = [])
+  {
+    $this->db     = $db;
+    $this->config = $config;
+    $this->ensureTables();
+  }
+
+  /**
+   * Fetch products from WooCommerce and store/update them in ERP database.
+   */
+  public function syncProducts()
+  {
+    try {
+      $products = $this->request('GET', '/products', ['per_page' => 100]);
+      if (empty($products)) {
+        return;
+      }
+      foreach ($products as $product) {
+        $sku   = $product['sku'];
+        if ($sku === '') {
+          continue;
+        }
+        $name  = $product['name'];
+        $id    = $this->db->Select('SELECT id FROM artikel WHERE nummer=:sku', $sku);
+        if ($id) {
+          $this->db->Update('UPDATE artikel SET name_de=:name WHERE id=:id', $name, $id);
+        } else {
+          $this->db->Insert('INSERT INTO artikel (typ, nummer, name_de) VALUES ("default", :sku, :name)', $sku, $name);
+        }
+        $this->db->Insert('REPLACE INTO marketplace_products (marketplace, external_id, sku, stock, data) VALUES ("woocommerce", :ext, :sku, :stock, :data)', $product['id'], $sku, $product['stock_quantity'], json_encode($product));
+      }
+    } catch (Exception $e) {
+      $this->logError('syncProducts: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Fetch orders from WooCommerce and store them in ERP database.
+   */
+  public function syncOrders()
+  {
+    try {
+      $orders = $this->request('GET', '/orders', ['per_page' => 50]);
+      if (empty($orders)) {
+        return;
+      }
+      foreach ($orders as $order) {
+        $externalId = $order['id'];
+        $exists = $this->db->Select('SELECT external_id FROM marketplace_orders WHERE marketplace="woocommerce" AND external_id=:id', $externalId);
+        if (!$exists) {
+          $this->db->Insert('INSERT INTO marketplace_orders (marketplace, external_id, status, data) VALUES ("woocommerce", :id, :status, :data)', $externalId, $order['status'], json_encode($order));
+        } else {
+          $this->db->Update('UPDATE marketplace_orders SET status=:status, data=:data WHERE marketplace="woocommerce" AND external_id=:id', $order['status'], json_encode($order), $externalId);
+        }
+      }
+    } catch (Exception $e) {
+      $this->logError('syncOrders: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Push local stock quantities to WooCommerce.
+   */
+  public function updateStock()
+  {
+    try {
+      $rows = $this->db->SelectArr('SELECT external_id, sku, stock FROM marketplace_products WHERE marketplace="woocommerce"');
+      if (empty($rows)) {
+        return;
+      }
+      foreach ($rows as $row) {
+        $this->request('PUT', '/products/' . $row['external_id'], ['stock_quantity' => (int)$row['stock']]);
+      }
+    } catch (Exception $e) {
+      $this->logError('updateStock: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Create invoice notes back to WooCommerce orders.
+   */
+  public function sendInvoices()
+  {
+    try {
+      $orders = $this->db->SelectArr('SELECT external_id, data FROM marketplace_orders WHERE marketplace="woocommerce" AND status="completed"');
+      if (empty($orders)) {
+        return;
+      }
+      foreach ($orders as $order) {
+        $data = json_decode($order['data'], true);
+        if (empty($data['invoice_number'])) {
+          continue;
+        }
+        $this->request('POST', '/orders/' . $order['external_id'] . '/notes', ['note' => 'Invoice ' . $data['invoice_number']]);
+      }
+    } catch (Exception $e) {
+      $this->logError('sendInvoices: ' . $e->getMessage());
+    }
+  }
+
+  /**
+   * Execute HTTP request against WooCommerce REST API.
+   *
+   * @param string $method
+   * @param string $endpoint
+   * @param array  $params
+   *
+   * @return array|null
+   * @throws Exception
+   */
+  private function request($method, $endpoint, array $params = [])
+  {
+    $base = rtrim($this->config['base_url'] ?? '', '/');
+    if ($base === '') {
+      throw new Exception('Missing base_url config');
+    }
+    $url = $base . '/wp-json/wc/v3' . $endpoint;
+    if ($method === 'GET' && !empty($params)) {
+      $url .= '?' . http_build_query($params);
+    }
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_USERPWD, ($this->config['consumer_key'] ?? '') . ':' . ($this->config['consumer_secret'] ?? ''));
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+    if ($method !== 'GET') {
+      curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+      curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($params));
+    }
+    $result = curl_exec($ch);
+    if ($result === false) {
+      throw new Exception(curl_error($ch));
+    }
+    $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($code >= 400) {
+      throw new Exception('HTTP ' . $code . ': ' . $result);
+    }
+    return json_decode($result, true);
+  }
+
+  /**
+   * Ensure helper tables exist for WooCommerce synchronisation.
+   */
+  private function ensureTables()
+  {
+    $this->db->Update('CREATE TABLE IF NOT EXISTS marketplace_products (marketplace VARCHAR(20), external_id VARCHAR(64), sku VARCHAR(64), stock INT, data LONGTEXT, PRIMARY KEY(marketplace, external_id))');
+    $this->db->Update('CREATE TABLE IF NOT EXISTS marketplace_orders (marketplace VARCHAR(20), external_id VARCHAR(64), status VARCHAR(32), data LONGTEXT, PRIMARY KEY(marketplace, external_id))');
+  }
+
+  private function logError($message)
+  {
+    error_log('[WooCommerceSync] ' . $message);
+  }
+}

--- a/www/pages/marketplacesync.php
+++ b/www/pages/marketplacesync.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Simple configuration UI placeholder for marketplace synchronisation.
+ */
+class MarketplaceSync
+{
+  /** @var Application */
+  var $app;
+
+  public function __construct($app)
+  {
+    $this->app = $app;
+    $this->app->ActionHandlerInit($this);
+    $this->app->ActionHandler('list', 'MarketplaceSyncList');
+    $this->app->ActionHandler('save', 'MarketplaceSyncSave');
+    $this->app->DefaultAction = 'list';
+  }
+
+  /**
+   * Display configuration form.
+   */
+  public function MarketplaceSyncList()
+  {
+    $config = $this->getConfig();
+    $html = '<h1>Marketplace Sync Configuration</h1>';
+    $html .= '<form method="post" action="?action=save">';
+    $html .= '<h2>Amazon</h2>';
+    $html .= 'Access Key <input type="text" name="amazon_access_key" value="'.htmlspecialchars($config['amazon']['access_key'] ?? '').'"><br>';
+    $html .= 'Secret Key <input type="text" name="amazon_secret_key" value="'.htmlspecialchars($config['amazon']['secret_key'] ?? '').'"><br>';
+    $html .= 'Marketplace ID <input type="text" name="amazon_marketplace_id" value="'.htmlspecialchars($config['amazon']['marketplace_id'] ?? '').'"><br>';
+    $html .= 'Region <input type="text" name="amazon_region" value="'.htmlspecialchars($config['amazon']['region'] ?? '').'"><br>';
+    $html .= 'Endpoint <input type="text" name="amazon_endpoint" value="'.htmlspecialchars($config['amazon']['endpoint'] ?? '').'"><br>';
+    $html .= 'LWA Access Token <input type="text" name="amazon_lwa_access_token" value="'.htmlspecialchars($config['amazon']['lwa_access_token'] ?? '').'"><br>';
+
+    $html .= '<h2>Mirakl</h2>';
+    $html .= 'Base URL <input type="text" name="mirakl_base_url" value="'.htmlspecialchars($config['mirakl']['base_url'] ?? '').'"><br>';
+    $html .= 'API Key <input type="text" name="mirakl_api_key" value="'.htmlspecialchars($config['mirakl']['api_key'] ?? '').'"><br>';
+
+    $html .= '<h2>WooCommerce</h2>';
+    $html .= 'Base URL <input type="text" name="woocommerce_base_url" value="'.htmlspecialchars($config['woocommerce']['base_url'] ?? '').'"><br>';
+    $html .= 'Consumer Key <input type="text" name="woocommerce_consumer_key" value="'.htmlspecialchars($config['woocommerce']['consumer_key'] ?? '').'"><br>';
+    $html .= 'Consumer Secret <input type="text" name="woocommerce_consumer_secret" value="'.htmlspecialchars($config['woocommerce']['consumer_secret'] ?? '').'"><br>';
+
+    $html .= '<button type="submit">Save</button>';
+    $html .= '</form>';
+    $this->app->Tpl->Add('PAGE', $html);
+  }
+
+  /**
+   * Save configuration from form.
+   */
+  public function MarketplaceSyncSave()
+  {
+    $this->ensureTable();
+    foreach ($_POST as $key => $value) {
+      if (strpos($key, 'amazon_') === 0) {
+        $marketplace = 'amazon';
+        $param = substr($key, 7);
+      } elseif (strpos($key, 'mirakl_') === 0) {
+        $marketplace = 'mirakl';
+        $param = substr($key, 7);
+      } elseif (strpos($key, 'woocommerce_') === 0) {
+        $marketplace = 'woocommerce';
+        $param = substr($key, 12);
+      } else {
+        continue;
+      }
+      $this->app->DB->Insert('REPLACE INTO marketplace_config (marketplace, param, value) VALUES (:m,:p,:v)', $marketplace, $param, $value);
+    }
+    $this->app->Tpl->Set('MESSAGE', 'Configuration saved');
+    $this->MarketplaceSyncList();
+  }
+
+  /**
+   * Load all marketplace config values.
+   */
+  private function getConfig()
+  {
+    $this->ensureTable();
+    $rows = $this->app->DB->SelectArr('SELECT marketplace, param, value FROM marketplace_config');
+    $config = [];
+    if ($rows) {
+      foreach ($rows as $row) {
+        $config[$row['marketplace']][$row['param']] = $row['value'];
+      }
+    }
+    return $config;
+  }
+
+  private function ensureTable()
+  {
+    $this->app->DB->Update('CREATE TABLE IF NOT EXISTS marketplace_config (marketplace VARCHAR(20), param VARCHAR(64), value TEXT, PRIMARY KEY (marketplace,param))');
+  }
+}


### PR DESCRIPTION
## Summary
- implement Amazon SP-API sync with signed requests and feed uploads
- add Mirakl and WooCommerce REST integrations with database mappings
- expose configuration UI and cronjobs loading marketplace credentials

## Testing
- `php -l www/lib/class.amazonsync.php`
- `php -l www/lib/class.miraklsync.php`
- `php -l www/lib/class.woocommercesync.php`
- `php -l cronjobs/amazonsync.php`
- `php -l cronjobs/miraklsync.php`
- `php -l cronjobs/woocommercesync.php`
- `php -l www/pages/marketplacesync.php`


------
https://chatgpt.com/codex/tasks/task_e_6897239ec598832e8927eba71038043c