### PR TITLE
Add Godot & Unreal RTS starter projects, container setup scripts, and docs

### DIFF
--- a/docs/container-rts-setup.md
+++ b/docs/container-rts-setup.md
@@ -1,0 +1,38 @@
+# Container RTS Setup
+
+Dieses Repo enthält Setup-Helfer für Container-Readiness:
+
+- `scripts/setup_container_rts.sh`  
+  Best-Effort Setup (Godot Download) + **Offline-Fallback aus `tools/`**.
+- `scripts/rts_env_check.sh`  
+  Prüft verfügbare Tools (`godot4`, `clang`, `cmake`, usw.).
+- `scripts/use_local_tools.sh`  
+  Lädt lokale/offline Tools in den `PATH` (`source` verwenden).
+
+## Online Setup
+
+```bash
+./scripts/setup_container_rts.sh
+./scripts/rts_env_check.sh
+```
+
+## Offline Fallback (wenn Downloads blockiert sind)
+
+1. Lege lokale Binaries in `tools/bin/` (z. B. `tools/bin/godot4`).
+2. Optional: entpacke Godot nach `tools/godot/`.
+3. Lade lokale Tools:
+
+```bash
+source scripts/use_local_tools.sh
+./scripts/rts_env_check.sh
+```
+
+## Wichtiger Hinweis
+
+In dieser Container-Umgebung können externe Paket-/Download-Quellen per Proxy blockiert sein (HTTP 403).
+Die Skripte sind daher **graceful** implementiert (Warnung statt Hard-Fail) und unterstützen jetzt explizit Offline-Fallback.
+
+## Erwartetes Ergebnis
+
+- Online verfügbar: `godot4 --version` über Auto-Install.
+- Online blockiert: Setup-Warnung + nutzbarer Offline-Pfad via `tools/`.

--- a/docs/godot-rts-starter.md
+++ b/docs/godot-rts-starter.md
@@ -1,0 +1,59 @@
+# Godot RTS Starter (mac-freundlich, vernetzt)
+
+Dieses Godot-4-Starterprojekt ist jetzt ein **vernetztes RTS-MVP+** mit nächsten Ausbaustufen:
+
+- Drag-Selection + Kontextbefehle
+- Attack-Move (`A` + RMB)
+- Command Queue (Shift + RMB)
+- Einheitenrollen: Soldier, Harvester, Scout, Tank
+- Einheiten mit HP, Aggro-Reichweite, Auto-Attack, Cooldowns
+- Ressourcenknoten + Harvester + Credits
+- Spieler-/Gegner-HQ als zerstörbare Ziele
+- Einfache KI-Wellen (inkl. Tank-Soldier-Mix)
+- Doktrin-System (F1/F2/F3): Swarm / Fortress / SpecOps
+- Sekundärziel: Control Beacon (Punkte-Win Condition)
+- **Fog-of-War light** (Gegner sichtbar bei Sichtkontakt)
+- **Radar-Pings** (`R`) mit temporären Marker-Echos
+- Produktion über Hotkeys (1..4)
+- WASD-Kamera
+
+## Starten auf macOS
+
+1. Godot 4.x installieren.
+2. `godot_starter/project.godot` im Project Manager importieren.
+3. Projekt starten (`Play`).
+
+## Controls
+
+- **LMB halten + ziehen**: Auswahlrechteck
+- **RMB**: Kontextbefehl (Attack, falls Ziel getroffen; sonst Move)
+- **Shift + RMB**: Command Queue
+- **A, dann RMB**: Attack-Move
+- **1/2/3/4**: Soldier/Harvester/Scout/Tank produzieren
+- **F1/F2/F3**: Doktrin wählen (einmalig pro Match)
+- **R**: Radar-Ping
+- **WASD**: Kamera bewegen
+
+## Ganzheitlicher Loop
+
+1. Harvester sichern Credits.
+2. Credits finanzieren Unit-Komposition.
+3. Doktrin prägt deinen Mid-/Lategame-Stil.
+4. Fog + Scout-Vision bestimmen Informationskontrolle.
+5. Beacon-Kontrolle erzwingt Map-Präsenz.
+6. HQ-Fall **oder** Beacon-Dominanz entscheidet das Match.
+
+## Wichtige Dateien
+
+- `godot_starter/scenes/Main.tscn`
+- `godot_starter/scenes/Beacon.tscn`
+- `godot_starter/scenes/PingMarker.tscn`
+- `godot_starter/scenes/Unit.tscn`
+- `godot_starter/scenes/Headquarters.tscn`
+- `godot_starter/scenes/ResourceNode.tscn`
+- `godot_starter/scripts/main.gd`
+- `godot_starter/scripts/beacon.gd`
+- `godot_starter/scripts/ping_marker.gd`
+- `godot_starter/scripts/unit.gd`
+- `godot_starter/scripts/headquarters.gd`
+- `godot_starter/scripts/resource_node.gd`

--- a/docs/unreal-rts-starter.md
+++ b/docs/unreal-rts-starter.md
@@ -1,0 +1,76 @@
+# Unreal RTS Starter (C&C-style)
+
+Dieses Starter-Paket ist jetzt so aufgebaut, dass du es direkt als UE5-C++-Projekt öffnen kannst (`unreal_starter/OpenXERTS.uproject`).
+
+## 1) Schnellstart (Projekt wirklich starten)
+
+1. **Unreal Engine 5.4+** installieren.
+2. Im Dateisystem zu `unreal_starter/` gehen.
+3. `OpenXERTS.uproject` doppelklicken.
+4. Wenn gefragt: C++-Projektdateien generieren und kompilieren.
+5. Projekt im Editor öffnen und eine Map unter `Content/RTS/Maps` anlegen.
+
+> Falls der Doppelklick nicht funktioniert, im Epic Launcher Unreal öffnen und die `.uproject` manuell wählen.
+
+## 2) Ziel-MVP
+
+- RTS-Kamera (Pan/Zoom/Rotate)
+- Box-Selection und Rechtsklick-Move
+- 1 Ressource + Sammler
+- HQ + Kaserne
+- Infanterie + Sammler
+- Auto-Attack in Reichweite
+- Einfache KI (spawnt Einheiten und greift an)
+
+## 3) Projektstruktur in diesem Repo
+
+- `unreal_starter/OpenXERTS.uproject`
+- `unreal_starter/Source/OpenXERTS/` (C++ Modul)
+- `unreal_starter/Source/OpenXERTS.Target.cs`
+- `unreal_starter/Source/OpenXERTSEditor.Target.cs`
+
+## 4) Bereits enthaltene C++-Basisklassen
+
+- `RTSPlayerController` (Input + Selection + Commands)
+- `RTSUnitBase` (HP, Move, Attack)
+
+### RTSUnitBase: Verhalten
+
+- Variablen:
+  - `TeamId` (int32)
+  - `MaxHealth`, `CurrentHealth`
+  - `AttackRange`, `AttackDamage`, `AttackInterval`
+  - `TargetActor`
+- Funktionen:
+  - `IssueMove(FVector)`
+  - `IssueAttack(AActor*)`
+  - `TakeRTSDamage(float)`
+
+## 5) Blueprint-Setup (im Editor)
+
+1. `BP_RTSPlayerController` von `RTSPlayerController`.
+2. `BP_RTSPawn` als Kamera-Pawn (neu erstellen).
+3. `BP_UnitBase` von `RTSUnitBase`.
+4. `BP_Soldier`, `BP_Harvester` als Child-Blueprints von `BP_UnitBase`.
+5. Optional: `BP_BuildingBase`, `BP_HQ`, `BP_Barracks` ergänzen.
+
+## 6) Input Mapping
+
+Wenn du klassisches Input nutzt:
+- Action `Select` auf LMB
+- Action `Command` auf RMB
+
+(Enhanced Input Plugin ist im `.uproject` bereits aktiviert.)
+
+## 7) Was als Nächstes fehlt, um „C&C-Feeling“ zu bekommen
+
+1. RTS-Kamera-Pawn (`BP_RTSPawn`) fertig bauen
+2. Mehrfachauswahl (Drag-Box) ergänzen
+3. Ressourcenkreislauf (Ernte -> Abgabe -> Konto)
+4. Produktions-Queue in Gebäuden
+5. Gegner-KI + Win/Lose Conditions
+
+## 8) Realistische Erwartung
+
+- **Ja, starten kannst du jetzt** (Projektdateien + Modul sind vorhanden).
+- Für ein wirklich spielbares Match fehlen noch die oben genannten Gameplay-Systeme und Blueprints.

--- a/godot_starter/project.godot
+++ b/godot_starter/project.godot
@@ -1,0 +1,23 @@
+; Engine configuration file.
+; Godot 4.x
+
+config_version=5
+
+[application]
+config/name="OpenXE RTS Godot Starter"
+run/main_scene="res://scenes/Main.tscn"
+
+[display]
+window/size/viewport_width=1600
+window/size/viewport_height=900
+window/stretch/mode="canvas_items"
+
+[input]
+select={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"device":-1,"button_index":1,"pressed":false)]
+}
+command={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"device":-1,"button_index":2,"pressed":false)]
+}

--- a/godot_starter/scenes/Beacon.tscn
+++ b/godot_starter/scenes/Beacon.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=2 format=3 uid="uid://openxe_beacon"]
+
+[ext_resource type="Script" path="res://scripts/beacon.gd" id="1"]
+
+[node name="Beacon" type="Area2D"]
+script = ExtResource("1")
+
+[node name="Ring" type="Line2D" parent="."]
+width = 2.0
+default_color = Color(0.9, 0.9, 0.9, 1)
+points = PackedVector2Array(120, 0, 85, 85, 0, 120, -85, 85, -120, 0, -85, -85, 0, -120, 85, -85, 120, 0)
+
+[node name="Label" type="Label" parent="."]
+position = Vector2(-70, -140)
+text = "Beacon: neutral"

--- a/godot_starter/scenes/Headquarters.tscn
+++ b/godot_starter/scenes/Headquarters.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=2 format=3 uid="uid://openxe_hq"]
+
+[ext_resource type="Script" path="res://scripts/headquarters.gd" id="1"]
+
+[node name="Headquarters" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Body" type="ColorRect" parent="."]
+position = Vector2(-30, -30)
+size = Vector2(60, 60)
+color = Color(0.3, 0.4, 0.8, 1)
+
+[node name="HPBar" type="ProgressBar" parent="."]
+position = Vector2(-35, -45)
+size = Vector2(70, 8)
+show_percentage = false
+max_value = 800.0
+value = 800.0

--- a/godot_starter/scenes/Main.tscn
+++ b/godot_starter/scenes/Main.tscn
@@ -1,0 +1,105 @@
+[gd_scene load_steps=8 format=3 uid="uid://openxe_main"]
+
+[ext_resource type="Script" path="res://scripts/main.gd" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/Unit.tscn" id="2"]
+[ext_resource type="PackedScene" path="res://scenes/Headquarters.tscn" id="3"]
+[ext_resource type="PackedScene" path="res://scenes/ResourceNode.tscn" id="4"]
+[ext_resource type="PackedScene" path="res://scenes/Beacon.tscn" id="5"]
+[ext_resource type="PackedScene" path="res://scenes/PingMarker.tscn" id="6"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1")
+unit_scene = ExtResource("2")
+ping_scene = ExtResource("6")
+
+[node name="Units" type="Node2D" parent="."]
+
+[node name="Structures" type="Node2D" parent="."]
+
+[node name="PlayerHQ" parent="Structures" instance=ExtResource("3")]
+position = Vector2(250, 700)
+
+[node name="EnemyHQ" parent="Structures" instance=ExtResource("3")]
+position = Vector2(1350, 180)
+team_id = 1
+
+[node name="Resources" type="Node2D" parent="."]
+
+[node name="NodeA" parent="Resources" instance=ExtResource("4")]
+position = Vector2(780, 470)
+
+[node name="NodeB" parent="Resources" instance=ExtResource("4")]
+position = Vector2(860, 520)
+
+[node name="NodeC" parent="Resources" instance=ExtResource("4")]
+position = Vector2(720, 560)
+
+[node name="Beacon" parent="." instance=ExtResource("5")]
+position = Vector2(800, 450)
+
+
+[node name="Pings" type="Node2D" parent="."]
+
+[node name="Camera2D" type="Camera2D" parent="."]
+position = Vector2(800, 450)
+enabled = true
+
+[node name="UI" type="CanvasLayer" parent="."]
+
+[node name="SelectionRect" type="ColorRect" parent="UI"]
+visible = false
+color = Color(0.2, 0.8, 1, 0.2)
+
+[node name="SelectionBorder" type="Panel" parent="UI/SelectionRect"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="HUD" type="MarginContainer" parent="UI"]
+offset_left = 8.0
+offset_top = 8.0
+offset_right = 760.0
+offset_bottom = 140.0
+
+[node name="VBox" type="VBoxContainer" parent="UI/HUD"]
+layout_mode = 2
+
+[node name="MoneyLabel" type="Label" parent="UI/HUD/VBox"]
+text = "Credits: 300"
+
+[node name="DoctrineLabel" type="Label" parent="UI/HUD/VBox"]
+text = "Doktrin: ungewählt (F1/F2/F3)"
+
+[node name="ObjectiveLabel" type="Label" parent="UI/HUD/VBox"]
+text = "Sekundärziel: Beacon halten"
+
+[node name="InfoLabel" type="Label" parent="UI/HUD/VBox"]
+text = ""
+
+[node name="PlayerSoldierA" parent="Units" instance=ExtResource("2")]
+position = Vector2(340, 680)
+team_id = 0
+role = 0
+
+[node name="PlayerSoldierB" parent="Units" instance=ExtResource("2")]
+position = Vector2(360, 725)
+team_id = 0
+role = 0
+
+[node name="PlayerHarvester" parent="Units" instance=ExtResource("2")]
+position = Vector2(300, 740)
+team_id = 0
+can_harvest = true
+attack_damage = 2.0
+max_health = 80.0
+role = 1
+
+[node name="EnemyGuardA" parent="Units" instance=ExtResource("2")]
+position = Vector2(1250, 240)
+team_id = 1
+role = 0
+
+[node name="EnemyGuardB" parent="Units" instance=ExtResource("2")]
+position = Vector2(1310, 260)
+team_id = 1
+role = 3

--- a/godot_starter/scenes/PingMarker.tscn
+++ b/godot_starter/scenes/PingMarker.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=2 format=3 uid="uid://openxe_ping"]
+
+[ext_resource type="Script" path="res://scripts/ping_marker.gd" id="1"]
+
+[node name="PingMarker" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Ring" type="Line2D" parent="."]
+width = 2.0
+default_color = Color(1, 1, 0.2, 1)
+points = PackedVector2Array(20, 0, 14, 14, 0, 20, -14, 14, -20, 0, -14, -14, 0, -20, 14, -14, 20, 0)
+
+[node name="Label" type="Label" parent="."]
+position = Vector2(-18, -32)
+text = "PING"

--- a/godot_starter/scenes/ResourceNode.tscn
+++ b/godot_starter/scenes/ResourceNode.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3 uid="uid://openxe_resource"]
+
+[ext_resource type="Script" path="res://scripts/resource_node.gd" id="1"]
+
+[node name="ResourceNode" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Gem" type="Polygon2D" parent="."]
+polygon = PackedVector2Array(0, -16, 14, -4, 10, 12, -10, 12, -14, -4)
+color = Color(0.2, 1, 0.5, 1)

--- a/godot_starter/scenes/Unit.tscn
+++ b/godot_starter/scenes/Unit.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=2 format=3 uid="uid://openxe_unit"]
+
+[ext_resource type="Script" path="res://scripts/unit.gd" id="1"]
+
+[node name="Unit" type="CharacterBody2D"]
+script = ExtResource("1")
+
+[node name="Body" type="Polygon2D" parent="."]
+polygon = PackedVector2Array(-10, -10, 10, -10, 10, 10, -10, 10)
+color = Color(0.75, 0.85, 1, 1)
+
+[node name="Selection" type="Line2D" parent="."]
+visible = false
+width = 2.0
+default_color = Color(0.2, 1, 0.2, 1)
+points = PackedVector2Array(-14, -14, 14, -14, 14, 14, -14, 14, -14, -14)
+
+[node name="HPBar" type="ProgressBar" parent="."]
+position = Vector2(-18, -24)
+size = Vector2(36, 6)
+show_percentage = false
+max_value = 100.0
+value = 100.0

--- a/godot_starter/scripts/beacon.gd
+++ b/godot_starter/scripts/beacon.gd
@@ -1,0 +1,64 @@
+extends Area2D
+class_name ControlBeacon
+
+signal captured(team_id: int)
+
+@export var radius: float = 120.0
+@export var hold_time_required: float = 20.0
+
+var controlling_team: int = -1
+var hold_progress: float = 0.0
+
+@onready var ring: Line2D = $Ring
+@onready var label: Label = $Label
+
+func _ready() -> void:
+    monitoring = true
+    ring.width = 2.0
+    _refresh_visual()
+
+func update_control(units: Array[RTSUnit], delta: float) -> void:
+    var p := 0
+    var e := 0
+    for u in units:
+        if not is_instance_valid(u):
+            continue
+        if global_position.distance_to(u.global_position) <= radius:
+            if u.team_id == 0:
+                p += 1
+            elif u.team_id == 1:
+                e += 1
+
+    var next_team := -1
+    if p > e and p > 0:
+        next_team = 0
+    elif e > p and e > 0:
+        next_team = 1
+
+    if next_team == -1:
+        hold_progress = max(hold_progress - delta * 0.5, 0.0)
+        if hold_progress == 0.0:
+            controlling_team = -1
+    elif controlling_team == next_team:
+        hold_progress = min(hold_progress + delta, hold_time_required)
+    else:
+        controlling_team = next_team
+        hold_progress = min(delta, hold_time_required)
+
+    if hold_progress >= hold_time_required:
+        captured.emit(controlling_team)
+        hold_progress = 0.0
+
+    _refresh_visual()
+
+func _refresh_visual() -> void:
+    var pct := int((hold_progress / hold_time_required) * 100.0)
+    if controlling_team == 0:
+        ring.default_color = Color(0.3, 0.7, 1.0, 1.0)
+        label.text = "Beacon: Spieler %d%%" % pct
+    elif controlling_team == 1:
+        ring.default_color = Color(1.0, 0.35, 0.3, 1.0)
+        label.text = "Beacon: Gegner %d%%" % pct
+    else:
+        ring.default_color = Color(0.9, 0.9, 0.9, 1.0)
+        label.text = "Beacon: neutral"

--- a/godot_starter/scripts/headquarters.gd
+++ b/godot_starter/scripts/headquarters.gd
@@ -1,0 +1,24 @@
+extends Node2D
+class_name Headquarters
+
+signal destroyed(team_id: int)
+
+@export var team_id: int = 0
+@export var max_health: float = 800.0
+
+var health: float
+
+@onready var hp_bar: ProgressBar = $HPBar
+
+func _ready() -> void:
+    add_to_group("damageable")
+    health = max_health
+    hp_bar.max_value = max_health
+    hp_bar.value = health
+
+func apply_damage(amount: float) -> void:
+    health = max(health - amount, 0.0)
+    hp_bar.value = health
+    if health <= 0.0:
+        destroyed.emit(team_id)
+        queue_free()

--- a/godot_starter/scripts/main.gd
+++ b/godot_starter/scripts/main.gd
@@ -1,0 +1,390 @@
+extends Node2D
+
+const TEAM_PLAYER := 0
+const TEAM_ENEMY := 1
+
+enum Doctrine { NONE, SWARM, FORTRESS, SPECOPS }
+
+@onready var selection_rect: ColorRect = $UI/SelectionRect
+@onready var units_root: Node2D = $Units
+@onready var pings_root: Node2D = $Pings
+@onready var resources_root: Node2D = $Resources
+@onready var player_hq: Headquarters = $Structures/PlayerHQ
+@onready var enemy_hq: Headquarters = $Structures/EnemyHQ
+@onready var beacon: ControlBeacon = $Beacon
+@onready var camera: Camera2D = $Camera2D
+@onready var money_label: Label = $UI/HUD/VBox/MoneyLabel
+@onready var doctrine_label: Label = $UI/HUD/VBox/DoctrineLabel
+@onready var objective_label: Label = $UI/HUD/VBox/ObjectiveLabel
+@onready var info_label: Label = $UI/HUD/VBox/InfoLabel
+
+@export var unit_scene: PackedScene
+@export var ping_scene: PackedScene
+
+var drag_selecting: bool = false
+var drag_start: Vector2
+var selected_units: Array[RTSUnit] = []
+var player_money: float = 300.0
+var attack_move_armed: bool = false
+var doctrine: Doctrine = Doctrine.NONE
+var beacon_points_player: int = 0
+var beacon_points_enemy: int = 0
+
+var ai_spawn_cd: float = 0.0
+var ai_attack_cd: float = 0.0
+
+func _ready() -> void:
+    _refresh_ui()
+    player_hq.destroyed.connect(_on_hq_destroyed)
+    enemy_hq.destroyed.connect(_on_hq_destroyed)
+    beacon.captured.connect(_on_beacon_captured)
+
+func _unhandled_input(event: InputEvent) -> void:
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+        if event.pressed:
+            drag_selecting = true
+            drag_start = event.position
+            selection_rect.position = drag_start
+            selection_rect.size = Vector2.ZERO
+            selection_rect.visible = true
+        else:
+            drag_selecting = false
+            _apply_selection()
+            selection_rect.visible = false
+
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+        var queued := Input.is_key_pressed(KEY_SHIFT)
+        _issue_context_command(event.position, queued)
+        attack_move_armed = false
+
+    if event is InputEventKey and event.pressed:
+        match event.keycode:
+            KEY_1:
+                _spawn_player_unit(RTSUnit.UnitRole.SOLDIER)
+            KEY_2:
+                _spawn_player_unit(RTSUnit.UnitRole.HARVESTER)
+            KEY_3:
+                _spawn_player_unit(RTSUnit.UnitRole.SCOUT)
+            KEY_4:
+                _spawn_player_unit(RTSUnit.UnitRole.TANK)
+            KEY_A:
+                attack_move_armed = true
+                info_label.text = "Attack-Move aktiv: RMB setzen"
+            KEY_F1:
+                _set_doctrine(Doctrine.SWARM)
+            KEY_F2:
+                _set_doctrine(Doctrine.FORTRESS)
+            KEY_F3:
+                _set_doctrine(Doctrine.SPECOPS)
+            KEY_R:
+                _radar_ping()
+
+func _process(delta: float) -> void:
+    _update_selection_box()
+    _camera_controls(delta)
+    _resource_loop(delta)
+    _ai_loop(delta)
+    _objective_loop(delta)
+    _visibility_loop()
+
+func _update_selection_box() -> void:
+    if drag_selecting:
+        var now: Vector2 = get_viewport().get_mouse_position()
+        var top_left := Vector2(min(drag_start.x, now.x), min(drag_start.y, now.y))
+        var size := Vector2(abs(now.x - drag_start.x), abs(now.y - drag_start.y))
+        selection_rect.position = top_left
+        selection_rect.size = size
+
+func _camera_controls(delta: float) -> void:
+    var dir := Vector2.ZERO
+    if Input.is_key_pressed(KEY_A) and not attack_move_armed:
+        dir.x -= 1
+    if Input.is_key_pressed(KEY_D):
+        dir.x += 1
+    if Input.is_key_pressed(KEY_W):
+        dir.y -= 1
+    if Input.is_key_pressed(KEY_S):
+        dir.y += 1
+    if dir != Vector2.ZERO:
+        camera.global_position += dir.normalized() * 450.0 * delta
+
+func _apply_selection() -> void:
+    for unit in selected_units:
+        unit.set_selected(false)
+    selected_units.clear()
+
+    var rect := Rect2(selection_rect.position, selection_rect.size)
+    for child in units_root.get_children():
+        if child is RTSUnit:
+            var unit := child as RTSUnit
+            if unit.team_id == TEAM_PLAYER and rect.has_point(unit.global_position):
+                unit.set_selected(true)
+                selected_units.append(unit)
+
+func _issue_context_command(screen_pos: Vector2, queued: bool) -> void:
+    if selected_units.is_empty():
+        return
+
+    var clicked_target := _find_attackable_target_at(screen_pos)
+    if clicked_target != null:
+        for unit in selected_units:
+            unit.issue_attack(clicked_target)
+        return
+
+    for i in selected_units.size():
+        var offset := Vector2((i % 4) * 18.0, (i / 4) * 18.0)
+        selected_units[i].issue_move(screen_pos + offset, queued, attack_move_armed)
+
+func _find_attackable_target_at(pos: Vector2) -> Node2D:
+    var candidates: Array[Node2D] = []
+    for child in units_root.get_children():
+        if child is RTSUnit:
+            var unit := child as RTSUnit
+            if unit.team_id == TEAM_ENEMY and unit.visible:
+                candidates.append(unit)
+    if enemy_hq.visible:
+        candidates.append(enemy_hq)
+
+    for target in candidates:
+        if not is_instance_valid(target):
+            continue
+        if target.global_position.distance_to(pos) < 28.0:
+            return target
+    return null
+
+func _resource_loop(_delta: float) -> void:
+    for child in units_root.get_children():
+        if child is RTSUnit:
+            var unit := child as RTSUnit
+            if not unit.can_harvest or unit.team_id != TEAM_PLAYER:
+                continue
+
+            if unit.carrying_amount <= 0.0:
+                var node := _nearest_resource(unit.global_position)
+                if node != null:
+                    unit.issue_move(node.global_position)
+                    if unit.global_position.distance_to(node.global_position) < 22.0:
+                        unit.carrying_amount += node.harvest(unit.carry_capacity)
+            else:
+                unit.issue_move(player_hq.global_position)
+                if unit.global_position.distance_to(player_hq.global_position) < 42.0:
+                    player_money += unit.carrying_amount
+                    if doctrine == Doctrine.SWARM:
+                        player_money += 2.0
+                    unit.carrying_amount = 0.0
+                    _refresh_ui()
+
+func _nearest_resource(origin: Vector2) -> ResourceNode:
+    var best: ResourceNode = null
+    var best_dist := INF
+    for child in resources_root.get_children():
+        if child is ResourceNode:
+            var node := child as ResourceNode
+            var d := origin.distance_squared_to(node.global_position)
+            if d < best_dist:
+                best_dist = d
+                best = node
+    return best
+
+func _spawn_player_unit(role: RTSUnit.UnitRole) -> void:
+    var cost := _role_cost(role)
+    if doctrine == Doctrine.SWARM and role == RTSUnit.UnitRole.SOLDIER:
+        cost -= 20.0
+
+    if player_money < cost:
+        info_label.text = "Nicht genug Ressourcen"
+        return
+
+    player_money -= cost
+    var u := unit_scene.instantiate() as RTSUnit
+    u.global_position = player_hq.global_position + Vector2(randf_range(-60, 60), randf_range(-60, 60))
+    u.team_id = TEAM_PLAYER
+    _apply_role_stats(u, role)
+    units_root.add_child(u)
+    _refresh_ui()
+
+func _apply_role_stats(unit: RTSUnit, role: RTSUnit.UnitRole) -> void:
+    unit.role = role
+    match role:
+        RTSUnit.UnitRole.SOLDIER:
+            unit.can_harvest = false
+            unit.move_speed = 220.0
+            unit.max_health = 120.0
+            unit.attack_damage = 10.0
+            unit.attack_range = 90.0
+        RTSUnit.UnitRole.HARVESTER:
+            unit.can_harvest = true
+            unit.move_speed = 170.0
+            unit.max_health = 90.0
+            unit.attack_damage = 2.0
+            unit.attack_range = 65.0
+            unit.carry_capacity = 35.0
+        RTSUnit.UnitRole.SCOUT:
+            unit.can_harvest = false
+            unit.move_speed = 310.0
+            unit.max_health = 70.0
+            unit.attack_damage = 6.0
+            unit.attack_range = 80.0
+            unit.aggro_range = 230.0
+        RTSUnit.UnitRole.TANK:
+            unit.can_harvest = false
+            unit.move_speed = 140.0
+            unit.max_health = 240.0
+            unit.attack_damage = 18.0
+            unit.attack_range = 120.0
+            unit.attack_cooldown = 1.3
+
+    if unit.team_id == TEAM_PLAYER:
+        if doctrine == Doctrine.FORTRESS:
+            unit.max_health *= 1.15
+            unit.health = unit.max_health
+        elif doctrine == Doctrine.SPECOPS:
+            unit.move_speed *= 1.12
+            unit.aggro_range *= 1.2
+
+func _role_cost(role: RTSUnit.UnitRole) -> float:
+    match role:
+        RTSUnit.UnitRole.SOLDIER:
+            return 100.0
+        RTSUnit.UnitRole.HARVESTER:
+            return 150.0
+        RTSUnit.UnitRole.SCOUT:
+            return 130.0
+        RTSUnit.UnitRole.TANK:
+            return 260.0
+    return 100.0
+
+func _ai_loop(delta: float) -> void:
+    ai_spawn_cd -= delta
+    ai_attack_cd -= delta
+
+    if ai_spawn_cd <= 0.0:
+        ai_spawn_cd = 4.0
+        var enemy := unit_scene.instantiate() as RTSUnit
+        enemy.global_position = enemy_hq.global_position + Vector2(randf_range(-50, 50), randf_range(-50, 50))
+        enemy.team_id = TEAM_ENEMY
+        _apply_role_stats(enemy, RTSUnit.UnitRole.SOLDIER if randi() % 2 == 0 else RTSUnit.UnitRole.TANK)
+        units_root.add_child(enemy)
+
+    if ai_attack_cd <= 0.0:
+        ai_attack_cd = 2.0
+        for child in units_root.get_children():
+            if child is RTSUnit:
+                var unit := child as RTSUnit
+                if unit.team_id == TEAM_ENEMY:
+                    var target := _closest_player_unit(unit.global_position)
+                    if target != null:
+                        unit.issue_attack(target)
+                    else:
+                        unit.issue_attack(player_hq)
+
+func _closest_player_unit(origin: Vector2) -> RTSUnit:
+    var best: RTSUnit = null
+    var best_dist := INF
+    for child in units_root.get_children():
+        if child is RTSUnit:
+            var unit := child as RTSUnit
+            if unit.team_id != TEAM_PLAYER:
+                continue
+            var d := origin.distance_squared_to(unit.global_position)
+            if d < best_dist:
+                best_dist = d
+                best = unit
+    return best
+
+func _objective_loop(delta: float) -> void:
+    var all_units: Array[RTSUnit] = []
+    for child in units_root.get_children():
+        if child is RTSUnit:
+            all_units.append(child as RTSUnit)
+    beacon.update_control(all_units, delta)
+
+func _on_beacon_captured(team_id: int) -> void:
+    if team_id == TEAM_PLAYER:
+        beacon_points_player += 1
+    elif team_id == TEAM_ENEMY:
+        beacon_points_enemy += 1
+
+    if beacon_points_player >= 3:
+        info_label.text = "Sieg - Beacon-Dominanz"
+    elif beacon_points_enemy >= 3:
+        info_label.text = "Niederlage - Beacon verloren"
+
+    _refresh_ui()
+
+func _set_doctrine(next: Doctrine) -> void:
+    if doctrine != Doctrine.NONE:
+        info_label.text = "Doktrin bereits gewählt"
+        return
+
+    doctrine = next
+    match doctrine:
+        Doctrine.SWARM:
+            doctrine_label.text = "Doktrin: Swarm (billige Soldiers + Eco-Bonus)"
+        Doctrine.FORTRESS:
+            doctrine_label.text = "Doktrin: Fortress (+15% HP)"
+            player_hq.max_health *= 1.25
+            player_hq.health = player_hq.max_health
+        Doctrine.SPECOPS:
+            doctrine_label.text = "Doktrin: SpecOps (+Mobility +Aggro)"
+    _refresh_ui()
+
+func _visibility_loop() -> void:
+    var player_units: Array[RTSUnit] = []
+    for c in units_root.get_children():
+        if c is RTSUnit and (c as RTSUnit).team_id == TEAM_PLAYER:
+            player_units.append(c as RTSUnit)
+
+    for c in units_root.get_children():
+        if c is RTSUnit and (c as RTSUnit).team_id == TEAM_ENEMY:
+            var enemy := c as RTSUnit
+            var seen := false
+            for p in player_units:
+                var sight := 250.0
+                if p.role == RTSUnit.UnitRole.SCOUT:
+                    sight = 360.0
+                if p.global_position.distance_to(enemy.global_position) <= sight:
+                    seen = true
+                    break
+            enemy.visible = seen
+            enemy.modulate.a = 1.0 if seen else 0.18
+
+    var hq_seen := false
+    for p in player_units:
+        var sight2 := 260.0
+        if p.role == RTSUnit.UnitRole.SCOUT:
+            sight2 = 380.0
+        if p.global_position.distance_to(enemy_hq.global_position) <= sight2:
+            hq_seen = true
+            break
+    enemy_hq.visible = hq_seen
+    enemy_hq.modulate.a = 1.0 if hq_seen else 0.25
+
+func _radar_ping() -> void:
+    if ping_scene == null:
+        return
+    for c in units_root.get_children():
+        if c is RTSUnit:
+            var u := c as RTSUnit
+            if u.team_id == TEAM_ENEMY:
+                var p := ping_scene.instantiate() as Node2D
+                p.global_position = u.global_position
+                pings_root.add_child(p)
+    var hq_ping := ping_scene.instantiate() as Node2D
+    hq_ping.global_position = enemy_hq.global_position
+    pings_root.add_child(hq_ping)
+    info_label.text = "Radar-Ping ausgelöst"
+
+func _on_hq_destroyed(team_id: int) -> void:
+    if team_id == TEAM_PLAYER:
+        info_label.text = "Niederlage - HQ zerstört"
+    else:
+        info_label.text = "Sieg - Gegnerbasis zerstört"
+
+func _refresh_ui() -> void:
+    money_label.text = "Credits: %d" % int(player_money)
+    objective_label.text = "Beacon-Punkte: %d / %d" % [beacon_points_player, beacon_points_enemy]
+    if doctrine == Doctrine.NONE:
+        doctrine_label.text = "Doktrin: ungewählt (F1/F2/F3)"
+    if info_label.text.is_empty():
+        info_label.text = "1/2/3/4 Units | A Attack-Move | Shift Queue | F1/F2/F3 | R Radar"

--- a/godot_starter/scripts/ping_marker.gd
+++ b/godot_starter/scripts/ping_marker.gd
@@ -1,0 +1,16 @@
+extends Node2D
+class_name PingMarker
+
+@export var duration: float = 3.0
+
+@onready var ring: Line2D = $Ring
+var ttl: float
+
+func _ready() -> void:
+    ttl = duration
+
+func _process(delta: float) -> void:
+    ttl -= delta
+    ring.width = 1.0 + sin(Time.get_ticks_msec() * 0.01) * 0.5 + 1.5
+    if ttl <= 0.0:
+        queue_free()

--- a/godot_starter/scripts/resource_node.gd
+++ b/godot_starter/scripts/resource_node.gd
@@ -1,0 +1,13 @@
+extends Node2D
+class_name ResourceNode
+
+@export var amount: float = 500.0
+
+func harvest(requested: float) -> float:
+    if amount <= 0.0:
+        return 0.0
+    var granted := min(amount, requested)
+    amount -= granted
+    if amount <= 0.0:
+        queue_free()
+    return granted

--- a/godot_starter/scripts/unit.gd
+++ b/godot_starter/scripts/unit.gd
@@ -1,0 +1,122 @@
+extends CharacterBody2D
+class_name RTSUnit
+
+signal died(unit: RTSUnit)
+
+enum UnitRole { SOLDIER, HARVESTER, SCOUT, TANK }
+
+@export var team_id: int = 0
+@export var role: UnitRole = UnitRole.SOLDIER
+@export var move_speed: float = 220.0
+@export var max_health: float = 100.0
+@export var attack_damage: float = 8.0
+@export var attack_range: float = 90.0
+@export var aggro_range: float = 180.0
+@export var attack_cooldown: float = 0.8
+@export var can_harvest: bool = false
+@export var carry_capacity: float = 25.0
+
+var health: float
+var selected: bool = false
+var move_target: Vector2
+var attack_target: Node2D
+var carrying_amount: float = 0.0
+var command_queue: Array[Vector2] = []
+var attack_move_mode: bool = false
+
+@onready var selection_outline: Line2D = $Selection
+@onready var hp_bar: ProgressBar = $HPBar
+
+var _attack_timer: float = 0.0
+
+func _ready() -> void:
+    add_to_group("damageable")
+    health = max_health
+    move_target = global_position
+    hp_bar.max_value = max_health
+    hp_bar.value = health
+    _update_selection_visual()
+
+func _physics_process(delta: float) -> void:
+    _attack_timer = max(_attack_timer - delta, 0.0)
+
+    if attack_move_mode and not is_instance_valid(attack_target):
+        attack_target = _find_enemy_in_aggro()
+
+    if is_instance_valid(attack_target):
+        var distance := global_position.distance_to(attack_target.global_position)
+        if distance <= attack_range:
+            velocity = Vector2.ZERO
+            _try_attack()
+        else:
+            _move_towards(attack_target.global_position)
+    else:
+        _move_towards(move_target)
+        if global_position.distance_to(move_target) < 4.0 and command_queue.size() > 0:
+            move_target = command_queue.pop_front()
+
+    move_and_slide()
+
+func issue_move(target: Vector2, queued: bool = false, attack_move: bool = false) -> void:
+    if not queued:
+        command_queue.clear()
+        attack_target = null
+    attack_move_mode = attack_move
+    if queued:
+        command_queue.append(target)
+    else:
+        move_target = target
+
+func issue_attack(target: Node2D) -> void:
+    if target == self:
+        return
+    if target is RTSUnit and (target as RTSUnit).team_id == team_id:
+        return
+    attack_target = target
+    attack_move_mode = false
+
+func set_selected(value: bool) -> void:
+    selected = value
+    _update_selection_visual()
+
+func apply_damage(amount: float) -> void:
+    health = max(health - amount, 0.0)
+    hp_bar.value = health
+    if health <= 0.0:
+        died.emit(self)
+        queue_free()
+
+func _move_towards(target: Vector2) -> void:
+    var to_target := target - global_position
+    if to_target.length() < 3.0:
+        velocity = Vector2.ZERO
+    else:
+        velocity = to_target.normalized() * move_speed
+
+func _try_attack() -> void:
+    if _attack_timer > 0.0:
+        return
+    _attack_timer = attack_cooldown
+    if is_instance_valid(attack_target) and attack_target.has_method("apply_damage"):
+        attack_target.call("apply_damage", attack_damage)
+
+func _find_enemy_in_aggro() -> Node2D:
+    var candidates := get_tree().get_nodes_in_group("damageable")
+    var best: Node2D = null
+    var best_dist := INF
+    for n in candidates:
+        if n == self:
+            continue
+        if n is RTSUnit and (n as RTSUnit).team_id == team_id:
+            continue
+        if n is Headquarters and (n as Headquarters).team_id == team_id:
+            continue
+        if n is Node2D:
+            var d := global_position.distance_squared_to((n as Node2D).global_position)
+            if d < best_dist and d <= aggro_range * aggro_range:
+                best_dist = d
+                best = n
+    return best
+
+func _update_selection_visual() -> void:
+    selection_outline.visible = selected

--- a/scripts/rts_env_check.sh
+++ b/scripts/rts_env_check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+check_cmd() {
+  local cmd="$1"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    echo "[OK] $cmd: $(command -v "$cmd")"
+  else
+    echo "[MISS] $cmd"
+  fi
+}
+
+echo "== OpenXE RTS environment check =="
+check_cmd bash
+check_cmd git
+check_cmd python3
+check_cmd curl
+check_cmd unzip
+check_cmd godot4
+check_cmd cmake
+check_cmd clang
+check_cmd dotnet
+
+echo
+if [[ -x "tools/bin/godot4" ]]; then
+  echo "[OFFLINE] tools/bin/godot4 vorhanden"
+else
+  echo "[OFFLINE] tools/bin/godot4 fehlt"
+fi
+
+echo "Hint: run ./scripts/setup_container_rts.sh to attempt auto-setup."
+echo "Hint: source scripts/use_local_tools.sh for offline fallback PATH."

--- a/scripts/setup_container_rts.sh
+++ b/scripts/setup_container_rts.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Best-effort setup for this container.
+# Works only when outbound network/proxy rules allow downloads.
+# Includes offline fallback support via ./tools.
+
+GODOT_VERSION="4.2.2-stable"
+GODOT_ZIP="Godot_v${GODOT_VERSION}_linux.x86_64.zip"
+GODOT_URL="https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/${GODOT_ZIP}"
+INSTALL_DIR="/opt/godot"
+BIN_PATH="/usr/local/bin/godot4"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+LOCAL_BIN="${REPO_ROOT}/tools/bin/godot4"
+LOCAL_GODOT_DIR="${REPO_ROOT}/tools/godot"
+
+echo "== OpenXE RTS setup (best effort) =="
+
+mkdir -p "$INSTALL_DIR"
+
+if command -v godot4 >/dev/null 2>&1; then
+  echo "godot4 already installed: $(godot4 --version || true)"
+else
+  echo "Downloading Godot from: $GODOT_URL"
+  if curl -fL "$GODOT_URL" -o "$INSTALL_DIR/godot.zip"; then
+    unzip -o "$INSTALL_DIR/godot.zip" -d "$INSTALL_DIR"
+    ln -sf "$INSTALL_DIR/Godot_v${GODOT_VERSION}_linux.x86_64" "$BIN_PATH"
+    chmod +x "$BIN_PATH"
+    echo "Installed godot4 -> $BIN_PATH"
+    godot4 --version || true
+  else
+    echo "[WARN] Godot download failed (likely network/proxy restriction)."
+    echo "       Trying offline fallback from repository tools/ ..."
+
+    if [[ -x "$LOCAL_BIN" ]]; then
+      ln -sf "$LOCAL_BIN" "$BIN_PATH"
+      echo "Linked offline fallback: $LOCAL_BIN -> $BIN_PATH"
+      godot4 --version || true
+    elif [[ -d "$LOCAL_GODOT_DIR" ]]; then
+      CANDIDATE="$(find "$LOCAL_GODOT_DIR" -maxdepth 2 -type f -name 'Godot*linux*x86_64*' | head -n 1 || true)"
+      if [[ -n "$CANDIDATE" ]]; then
+        chmod +x "$CANDIDATE"
+        ln -sf "$CANDIDATE" "$BIN_PATH"
+        echo "Linked offline fallback: $CANDIDATE -> $BIN_PATH"
+        godot4 --version || true
+      else
+        echo "[WARN] No executable Godot binary found in tools/godot/."
+      fi
+    else
+      echo "[WARN] No offline tools found."
+      echo "       Put godot binary into tools/bin/godot4 and rerun setup."
+    fi
+  fi
+fi
+
+echo
+echo "Running environment check..."
+"$(dirname "$0")/rts_env_check.sh"

--- a/scripts/use_local_tools.sh
+++ b/scripts/use_local_tools.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load local/offline tools from repo without network installs.
+# Usage:
+#   source scripts/use_local_tools.sh
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOLS_DIR="${ROOT_DIR}/tools"
+BIN_DIR="${TOOLS_DIR}/bin"
+
+if [[ -d "$BIN_DIR" ]]; then
+  export PATH="$BIN_DIR:$PATH"
+fi
+
+# Common optional folders for manually extracted tools
+if [[ -d "${TOOLS_DIR}/godot" ]]; then
+  export PATH="${TOOLS_DIR}/godot:$PATH"
+fi
+
+if [[ -f "${TOOLS_DIR}/tools.env" ]]; then
+  # shellcheck disable=SC1090
+  source "${TOOLS_DIR}/tools.env"
+fi
+
+echo "Local tools loaded. PATH prefixed with:"
+echo "  - ${BIN_DIR}"
+echo "  - ${TOOLS_DIR}/godot (if present)"

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,26 @@
+# Offline Tools Fallback
+
+Wenn der Container keine externen Downloads zulässt (z. B. Proxy 403), kannst du Tools lokal in dieses Verzeichnis legen.
+
+## Schnellstart
+
+1. Lege Binaries oder Symlinks in `tools/bin/` ab.
+2. Optional: entpacke Godot nach `tools/godot/`.
+3. Optional: nutze `tools/tools.env` für zusätzliche Pfade.
+4. Lade die Umgebung:
+
+```bash
+source scripts/use_local_tools.sh
+```
+
+## Erwartete Struktur
+
+- `tools/bin/godot4` (oder Symlink)
+- `tools/godot/` (optional)
+- `tools/tools.env` (optional)
+
+Beispiel `tools/tools.env`:
+
+```bash
+export PATH="/custom/path/to/tools:$PATH"
+```

--- a/tools/tools.env.example
+++ b/tools/tools.env.example
@@ -1,0 +1,2 @@
+# Copy to tools/tools.env and adjust as needed.
+# export PATH="/custom/path/to/tools:$PATH"

--- a/unreal_starter/OpenXERTS.uproject
+++ b/unreal_starter/OpenXERTS.uproject
@@ -1,0 +1,19 @@
+{
+  "FileVersion": 3,
+  "EngineAssociation": "5.4",
+  "Category": "Games",
+  "Description": "OpenXERTS - Unreal RTS starter project",
+  "Modules": [
+    {
+      "Name": "OpenXERTS",
+      "Type": "Runtime",
+      "LoadingPhase": "Default"
+    }
+  ],
+  "Plugins": [
+    {
+      "Name": "EnhancedInput",
+      "Enabled": true
+    }
+  ]
+}

--- a/unreal_starter/Source/OpenXERTS.Target.cs
+++ b/unreal_starter/Source/OpenXERTS.Target.cs
@@ -1,0 +1,13 @@
+using UnrealBuildTool;
+using System.Collections.Generic;
+
+public class OpenXERTSTarget : TargetRules
+{
+    public OpenXERTSTarget(TargetInfo Target) : base(Target)
+    {
+        Type = TargetType.Game;
+        DefaultBuildSettings = BuildSettingsVersion.V5;
+        IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_4;
+        ExtraModuleNames.Add("OpenXERTS");
+    }
+}

--- a/unreal_starter/Source/OpenXERTS/OpenXERTS.Build.cs
+++ b/unreal_starter/Source/OpenXERTS/OpenXERTS.Build.cs
@@ -1,0 +1,19 @@
+using UnrealBuildTool;
+
+public class OpenXERTS : ModuleRules
+{
+    public OpenXERTS(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(new[]
+        {
+            "Core",
+            "CoreUObject",
+            "Engine",
+            "InputCore",
+            "AIModule",
+            "EnhancedInput"
+        });
+    }
+}

--- a/unreal_starter/Source/OpenXERTS/OpenXERTS.cpp
+++ b/unreal_starter/Source/OpenXERTS/OpenXERTS.cpp
@@ -1,0 +1,4 @@
+#include "OpenXERTS.h"
+#include "Modules/ModuleManager.h"
+
+IMPLEMENT_PRIMARY_GAME_MODULE(FDefaultGameModuleImpl, OpenXERTS, "OpenXERTS");

--- a/unreal_starter/Source/OpenXERTS/OpenXERTS.h
+++ b/unreal_starter/Source/OpenXERTS/OpenXERTS.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/unreal_starter/Source/OpenXERTS/RTSPlayerController.cpp
+++ b/unreal_starter/Source/OpenXERTS/RTSPlayerController.cpp
@@ -1,0 +1,73 @@
+#include "RTSPlayerController.h"
+#include "RTSUnitBase.h"
+#include "Engine/World.h"
+
+ARTSPlayerController::ARTSPlayerController()
+{
+    bShowMouseCursor = true;
+    bEnableClickEvents = true;
+    bEnableMouseOverEvents = true;
+}
+
+void ARTSPlayerController::SetupInputComponent()
+{
+    Super::SetupInputComponent();
+
+    check(InputComponent);
+    InputComponent->BindAction("Select", IE_Pressed, this, &ARTSPlayerController::HandleLeftClick);
+    InputComponent->BindAction("Command", IE_Pressed, this, &ARTSPlayerController::HandleRightClick);
+}
+
+void ARTSPlayerController::HandleLeftClick()
+{
+    SelectSingleUnderCursor();
+}
+
+void ARTSPlayerController::HandleRightClick()
+{
+    CommandMoveOrAttackUnderCursor();
+}
+
+void ARTSPlayerController::SelectSingleUnderCursor()
+{
+    FHitResult Hit;
+    GetHitResultUnderCursor(ECC_Visibility, false, Hit);
+
+    SelectedUnits.Empty();
+    if (ARTSUnitBase* Unit = Cast<ARTSUnitBase>(Hit.GetActor()))
+    {
+        SelectedUnits.Add(Unit);
+    }
+}
+
+void ARTSPlayerController::CommandMoveOrAttackUnderCursor()
+{
+    if (SelectedUnits.IsEmpty())
+    {
+        return;
+    }
+
+    FHitResult Hit;
+    GetHitResultUnderCursor(ECC_Visibility, false, Hit);
+
+    if (ARTSUnitBase* TargetUnit = Cast<ARTSUnitBase>(Hit.GetActor()))
+    {
+        for (ARTSUnitBase* Unit : SelectedUnits)
+        {
+            if (IsValid(Unit) && Unit != TargetUnit)
+            {
+                Unit->IssueAttack(TargetUnit);
+            }
+        }
+        return;
+    }
+
+    const FVector Dest = Hit.ImpactPoint;
+    for (ARTSUnitBase* Unit : SelectedUnits)
+    {
+        if (IsValid(Unit))
+        {
+            Unit->IssueMove(Dest);
+        }
+    }
+}

--- a/unreal_starter/Source/OpenXERTS/RTSPlayerController.h
+++ b/unreal_starter/Source/OpenXERTS/RTSPlayerController.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/PlayerController.h"
+#include "RTSPlayerController.generated.h"
+
+class ARTSUnitBase;
+
+UCLASS()
+class OPENXERTS_API ARTSPlayerController : public APlayerController
+{
+    GENERATED_BODY()
+
+public:
+    ARTSPlayerController();
+
+protected:
+    virtual void SetupInputComponent() override;
+
+private:
+    UPROPERTY()
+    TArray<ARTSUnitBase*> SelectedUnits;
+
+    void HandleLeftClick();
+    void HandleRightClick();
+    void SelectSingleUnderCursor();
+    void CommandMoveOrAttackUnderCursor();
+};

--- a/unreal_starter/Source/OpenXERTS/RTSUnitBase.cpp
+++ b/unreal_starter/Source/OpenXERTS/RTSUnitBase.cpp
@@ -1,0 +1,72 @@
+#include "RTSUnitBase.h"
+#include "AIController.h"
+
+ARTSUnitBase::ARTSUnitBase()
+{
+    PrimaryActorTick.bCanEverTick = true;
+}
+
+void ARTSUnitBase::BeginPlay()
+{
+    Super::BeginPlay();
+    CurrentHealth = MaxHealth;
+}
+
+void ARTSUnitBase::Tick(float DeltaSeconds)
+{
+    Super::Tick(DeltaSeconds);
+    TryAttack(DeltaSeconds);
+}
+
+void ARTSUnitBase::IssueMove(const FVector& Destination)
+{
+    if (AAIController* AI = Cast<AAIController>(GetController()))
+    {
+        AI->MoveToLocation(Destination, 10.f, true, true, false);
+    }
+}
+
+void ARTSUnitBase::IssueAttack(AActor* InTarget)
+{
+    TargetActor = InTarget;
+}
+
+void ARTSUnitBase::TakeRTSDamage(float DamageAmount)
+{
+    CurrentHealth = FMath::Clamp(CurrentHealth - DamageAmount, 0.f, MaxHealth);
+    if (CurrentHealth <= 0.f)
+    {
+        Destroy();
+    }
+}
+
+void ARTSUnitBase::TryAttack(float DeltaSeconds)
+{
+    if (!IsValid(TargetActor))
+    {
+        return;
+    }
+
+    TimeSinceLastAttack += DeltaSeconds;
+    if (TimeSinceLastAttack < AttackInterval)
+    {
+        return;
+    }
+
+    const float Dist = FVector::Dist(GetActorLocation(), TargetActor->GetActorLocation());
+    if (Dist > AttackRange)
+    {
+        if (AAIController* AI = Cast<AAIController>(GetController()))
+        {
+            AI->MoveToActor(TargetActor, AttackRange * 0.8f);
+        }
+        return;
+    }
+
+    TimeSinceLastAttack = 0.f;
+
+    if (ARTSUnitBase* UnitTarget = Cast<ARTSUnitBase>(TargetActor))
+    {
+        UnitTarget->TakeRTSDamage(AttackDamage);
+    }
+}

--- a/unreal_starter/Source/OpenXERTS/RTSUnitBase.h
+++ b/unreal_starter/Source/OpenXERTS/RTSUnitBase.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Character.h"
+#include "RTSUnitBase.generated.h"
+
+UCLASS()
+class OPENXERTS_API ARTSUnitBase : public ACharacter
+{
+    GENERATED_BODY()
+
+public:
+    ARTSUnitBase();
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RTS|Team")
+    int32 TeamId = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RTS|Stats")
+    float MaxHealth = 100.f;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="RTS|Stats")
+    float CurrentHealth = 100.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RTS|Combat")
+    float AttackRange = 300.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RTS|Combat")
+    float AttackDamage = 10.f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RTS|Combat")
+    float AttackInterval = 1.0f;
+
+    UFUNCTION(BlueprintCallable, Category="RTS|Commands")
+    void IssueMove(const FVector& Destination);
+
+    UFUNCTION(BlueprintCallable, Category="RTS|Commands")
+    void IssueAttack(AActor* InTarget);
+
+    UFUNCTION(BlueprintCallable, Category="RTS|Combat")
+    void TakeRTSDamage(float DamageAmount);
+
+protected:
+    virtual void BeginPlay() override;
+    virtual void Tick(float DeltaSeconds) override;
+
+private:
+    UPROPERTY()
+    AActor* TargetActor = nullptr;
+
+    float TimeSinceLastAttack = 0.f;
+
+    void TryAttack(float DeltaSeconds);
+};

--- a/unreal_starter/Source/OpenXERTSEditor.Target.cs
+++ b/unreal_starter/Source/OpenXERTSEditor.Target.cs
@@ -1,0 +1,13 @@
+using UnrealBuildTool;
+using System.Collections.Generic;
+
+public class OpenXERTSEditorTarget : TargetRules
+{
+    public OpenXERTSEditorTarget(TargetInfo Target) : base(Target)
+    {
+        Type = TargetType.Editor;
+        DefaultBuildSettings = BuildSettingsVersion.V5;
+        IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_4;
+        ExtraModuleNames.Add("OpenXERTS");
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide ready-to-run RTS starter projects for Godot and Unreal and document how to run them. 
- Make container-based development resilient to blocked outbound downloads by adding best-effort setup and an explicit offline tools fallback. 

### Description

- Add container setup and helper scripts: `scripts/setup_container_rts.sh`, `scripts/rts_env_check.sh`, and `scripts/use_local_tools.sh`, plus `tools/README.md` and `tools/tools.env.example` for offline tooling conventions. 
- Add a Godot 4 starter: `godot_starter/project.godot`, scenes (`Main.tscn`, `Unit.tscn`, `Beacon.tscn`, `Headquarters.tscn`, `ResourceNode.tscn`, `PingMarker.tscn`), and gameplay scripts (`main.gd`, `unit.gd`, `beacon.gd`, `headquarters.gd`, `resource_node.gd`, `ping_marker.gd`) implementing selection, commands, resources, beacon control, doctrines, fog-of-war light, radar pings and AI spawning. 
- Add an Unreal Engine 5 starter C++ module under `unreal_starter/` including `OpenXERTS.uproject`, module build/target files and basic classes `RTSPlayerController` and `RTSUnitBase` to provide selection/command and unit behavior scaffolding. 
- `setup_container_rts.sh` attempts to download Godot, and if that fails due to network/proxy it will link an executable from `tools/` as an offline fallback; `rts_env_check.sh` reports presence of expected host tools. 

### Testing

- Ran `scripts/rts_env_check.sh` to verify tool detection and it completed reporting available/missing tools. 
- Sourced `scripts/use_local_tools.sh` to confirm the `PATH` is prefixed with `tools/bin` (offline loading) and it executed without error. 
- No automated unit tests exist for the new game code in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb71dad1f4832e8d359e2bbdde9e1f)